### PR TITLE
Share the TritonTF model across instances on same device

### DIFF
--- a/src/tensorflow.cc
+++ b/src/tensorflow.cc
@@ -690,6 +690,7 @@ class ModelState : public BackendModel {
   static constexpr int MODEL_DEVICE = -2;
 
   struct Model {
+    Model() : tritontf_model_(nullptr), input_device_id_(MODEL_DEVICE) {}
     // Map from configuration name for an input to tensor name for
     // that input in the model.
     IONameMap input_name_map_;

--- a/src/tensorflow.cc
+++ b/src/tensorflow.cc
@@ -680,9 +680,7 @@ SetStringOutputBuffer(
 //
 class ModelState : public BackendModel {
  public:
-  // GPU device number that indicates that no gpu is available for a
-  // context (which is an invalid state since TensorRT requires a
-  // GPU).
+  // GPU device number that indicates model will be loaded on CPU.
   static constexpr int NO_GPU_DEVICE = -1;
 
   // GPU device number that indicates model will be loaded on GPUs


### PR DESCRIPTION
However, I don't see any performance improvement:
config
```
cat models/resnet_v1_50_savedmodel/config.pbtxt 
name: "resnet_v1_50_savedmodel"
platform: "tensorflow_savedmodel"
max_batch_size: 128
input [
  {
    name: "input"
    data_type: TYPE_FP32
    format: FORMAT_NHWC
    dims: [ 224, 224, 3 ]
  }
]
output [
  {
    name: "output"
    data_type: TYPE_FP32
    dims: [ 1000 ]
    label_filename: "resnet50_labels.txt"
  }
]
instance_group [ {count: 4} ]
```
before
```
qa/clients/perf_analyzer -m resnet_v1_50_savedmodel -b 128 --concurrency-range 4:4:1
*** Measurement Settings ***
  Batch size: 128
  Measurement window: 5000 msec
  Latency limit: 0 msec
  Concurrency limit: 4 concurrent requests
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 4
  Client: 
    Request count: 46
    Throughput: 1177.6 infer/sec
    Avg latency: 443769 usec (standard deviation 33161 usec)
    p50 latency: 451443 usec
    p90 latency: 470631 usec
    p95 latency: 478158 usec
    p99 latency: 541150 usec
    Avg HTTP time: 445176 usec (send/recv 133191 usec + response wait 311985 usec)
  Server: 
    Inference count: 6912
    Execution count: 54
    Successful request count: 54
    Avg request latency: 296588 usec (overhead 48 usec + queue 54 usec + compute input 65821 usec + compute infer 230548 usec + compute output 117 usec)

Inferences/Second vs. Client Average Batch Latency
Concurrency: 4, throughput: 1177.6 infer/sec, latency 443769 usec
```
after
```
qa/clients/perf_analyzer -m resnet_v1_50_savedmodel -b 128 --concurrency-range 4:4:1
*** Measurement Settings ***
  Batch size: 128
  Measurement window: 5000 msec
  Latency limit: 0 msec
  Concurrency limit: 4 concurrent requests
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 4
  Client: 
    Request count: 45
    Throughput: 1152 infer/sec
    Avg latency: 432710 usec (standard deviation 36968 usec)
    p50 latency: 435244 usec
    p90 latency: 468676 usec
    p95 latency: 485366 usec
    p99 latency: 544514 usec
    Avg HTTP time: 431544 usec (send/recv 131653 usec + response wait 299891 usec)
  Server: 
    Inference count: 7296
    Execution count: 57
    Successful request count: 57
    Avg request latency: 283689 usec (overhead 47 usec + queue 54 usec + compute input 62902 usec + compute infer 220574 usec + compute output 112 usec)

Inferences/Second vs. Client Average Batch Latency
Concurrency: 4, throughput: 1152 infer/sec, latency 432710 usec
```