### PR TITLE
[WIP]fix tensorflow init bug

### DIFF
--- a/src/tensorflow_backend_tf.cc
+++ b/src/tensorflow_backend_tf.cc
@@ -530,6 +530,7 @@ ModelImpl::Run(
     const std::vector<std::string>& output_names,
     TRITONTF_TensorList** output_tensors)
 {
+  RETURN_IF_TF_ERROR(session_->Run({},{},{"init_all_vars_op"},nullptr));
   // I/O needs to be prepared differently for callable
   if (has_callable_) {
     std::vector<tensorflow::Tensor> tfinputs;


### PR DESCRIPTION
*DO NOT MERGE* This code doesn't fix the issue.


trying to add the equivalent of adding the C++ equivalent of sess.run([tf.global_variables_initializer(), tf.local_variables_initializer()]) 




reference:
https://github.com/tensorflow/tensorflow/issues/856
https://stackoverflow.com/questions/44775176/initialize-variables-in-tensorflow-c-api
https://stackoverflow.com/questions/34975884/how-to-invoke-tf-initialize-all-variables-in-c-tensorflow