### PR TITLE
Fix build to not use hardcoded gitlab TF image

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ if (${TRITON_TENSORFLOW_DOCKER_BUILD})
     COMMAND docker cp tensorflow_backend_tflib:/usr/local/lib/tensorflow/${TRITON_TENSORFLOW_CC_LIBNAME}.${TRITON_TENSORFLOW_VERSION} ${TRITON_TENSORFLOW_CC_LIBNAME}.${TRITON_TENSORFLOW_VERSION}
     COMMAND docker cp tensorflow_backend_tflib:${TRITON_TENSORFLOW_PYTHON_PATH}/${TRITON_TENSORFLOW_FW_LIBNAME}.${TRITON_TENSORFLOW_VERSION} ${TRITON_TENSORFLOW_FW_LIBNAME}.${TRITON_TENSORFLOW_VERSION}
     COMMAND docker cp tensorflow_backend_tflib:/opt/tensorflow/tensorflow-source/LICENSE LICENSE.tensorflow
-    COMMAND if [ "${TRITON_TENSORFLOW_INSTALL_EXTRA_DEPS}" = "ON" ] \; then docker cp tensorflow_backend_tflib:/usr/lib/x86_64-linux-gnu/libnccl.so libnccl.so \; fi \;
+    COMMAND if [ "${TRITON_TENSORFLOW_INSTALL_EXTRA_DEPS}" = "ON" ] \; then docker cp tensorflow_backend_tflib:/usr/lib/x86_64-linux-gnu/libnccl.so.2.11.4 libnccl.so \; fi \;
     COMMAND docker rm tensorflow_backend_tflib
     COMMENT "Extracting ${TRITON_TENSORFLOW_CC_LIBNAME}.${TRITON_TENSORFLOW_VERSION} and ${TRITON_TENSORFLOW_FW_LIBNAME}.${TRITON_TENSORFLOW_VERSION} from ${TRITON_TENSORFLOW_DOCKER_IMAGE}"
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -106,6 +106,11 @@ if(${TRITON_ENABLE_GPU})
   find_package(CUDAToolkit REQUIRED)
 endif() # TRITON_ENABLE_GPU
 
+# Install NCCL as extra dependency
+if(${TRITON_TENSORFLOW_INSTALL_EXTRA_DEPS})
+  set(EXTRA_LIBS "libnccl.so")
+endif() # TRITON_TENSORFLOW_INSTALL_EXTRA_DEPS
+
 #
 # Shared library implementing the Triton Backend API
 #
@@ -124,22 +129,15 @@ if (${TRITON_TENSORFLOW_DOCKER_BUILD})
       ${TRITON_TENSORFLOW_CC_LIBNAME}.${TRITON_TENSORFLOW_VERSION}
       ${TRITON_TENSORFLOW_FW_LIBNAME}.${TRITON_TENSORFLOW_VERSION}
       LICENSE.tensorflow
+      ${EXTRA_LIBS}
     COMMAND docker pull ${TRITON_TENSORFLOW_DOCKER_IMAGE}
     COMMAND docker rm tensorflow_backend_tflib || echo "error ignored..." || true
     COMMAND docker create --name tensorflow_backend_tflib ${TRITON_TENSORFLOW_DOCKER_IMAGE}
     COMMAND docker cp tensorflow_backend_tflib:/usr/local/lib/tensorflow/${TRITON_TENSORFLOW_CC_LIBNAME}.${TRITON_TENSORFLOW_VERSION} ${TRITON_TENSORFLOW_CC_LIBNAME}.${TRITON_TENSORFLOW_VERSION}
     COMMAND docker cp tensorflow_backend_tflib:${TRITON_TENSORFLOW_PYTHON_PATH}/${TRITON_TENSORFLOW_FW_LIBNAME}.${TRITON_TENSORFLOW_VERSION} ${TRITON_TENSORFLOW_FW_LIBNAME}.${TRITON_TENSORFLOW_VERSION}
     COMMAND docker cp tensorflow_backend_tflib:/opt/tensorflow/tensorflow-source/LICENSE LICENSE.tensorflow
+    COMMAND if [ "${TRITON_TENSORFLOW_INSTALL_EXTRA_DEPS}" = "ON" ] \; then docker cp tensorflow_backend_tflib:/usr/lib/x86_64-linux-gnu/libnccl.so libnccl.so \; fi \;
     COMMAND docker rm tensorflow_backend_tflib
-
-    COMMAND docker stop tensorflow_backend_deps || echo "error ignored..." || true
-    COMMAND docker rm tensorflow_backend_deps || echo "error ignored..." || true
-    COMMAND docker run -it -d --name tensorflow_backend_deps gitlab-master.nvidia.com:5005/dl/dgx/tensorflow:master-py3-base
-    COMMAND mkdir tf_backend_deps
-    COMMAND docker exec tensorflow_backend_deps sh -c  "tar -cf - /usr/lib/x86_64-linux-gnu/libnccl.so*" | tar --strip-components=3 -xf - -C ./tf_backend_deps
-    COMMAND docker stop tensorflow_backend_deps
-    COMMAND docker rm tensorflow_backend_deps
-
     COMMENT "Extracting ${TRITON_TENSORFLOW_CC_LIBNAME}.${TRITON_TENSORFLOW_VERSION} and ${TRITON_TENSORFLOW_FW_LIBNAME}.${TRITON_TENSORFLOW_VERSION} from ${TRITON_TENSORFLOW_DOCKER_IMAGE}"
   )
 
@@ -292,10 +290,12 @@ if (${TRITON_TENSORFLOW_DOCKER_BUILD})
   )
 
   if(${TRITON_TENSORFLOW_INSTALL_EXTRA_DEPS})
-    install(
-      DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tf_backend_deps/
-      DESTINATION ${TRITON_TENSORFLOW_BACKEND_INSTALLDIR}
-    )
+    FOREACH(extralib ${EXTRA_LIBS})
+      install(
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/${extralib}
+        DESTINATION ${TRITON_TENSORFLOW_BACKEND_INSTALLDIR}
+      )
+    ENDFOREACH(extralib)
   endif() # TRITON_TENSORFLOW_INSTALL_EXTRA_DEPS
 endif() # TRITON_TENSORFLOW_DOCKER_BUILD
 


### PR DESCRIPTION
- Do not copy NCCL libs if TRITON_TENSORFLOW_INSTALL_EXTRA_DEPS is OFF
Solves https://github.com/triton-inference-server/server/issues/3962