### PR TITLE
Default max_batch_size changed to 4

### DIFF
--- a/src/tensorflow.cc
+++ b/src/tensorflow.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/tensorflow.cc
+++ b/src/tensorflow.cc
@@ -1285,7 +1285,7 @@ AutoCompleteHelper::FixBatchingSupport()
   // agree. We need to update the configuration itself as well as the
   // cached value we have already initialized in the model state.
   if (max_batch_size == 0) {
-    const int new_max_batch_size = model_support_batching_ ? 1 : 0;
+    const int new_max_batch_size = model_support_batching_ ? 4 : 0;
 
     triton::common::TritonJson::Value mbs_value;
     model_state_->ModelConfig().Find("max_batch_size", &mbs_value);
@@ -1295,7 +1295,7 @@ AutoCompleteHelper::FixBatchingSupport()
     if (model_support_batching_ == 1) {
       LOG_MESSAGE(
           TRITONSERVER_LOG_WARN,
-          (std::string("autofilled max_batch_size to 1 for model '") +
+          (std::string("autofilled max_batch_size to 4 for model '") +
            model_state_->Name() +
            "' since batching is supporrted but no max_batch_size is specified "
            "in model configuration. Must specify max_batch_size to utilize "


### PR DESCRIPTION
If the model config can be autofilled and the model supports batching, we now default to a max_batch_size of 4 instead of 1.