### PR TITLE
Handle models that can return empty outputs

### DIFF
--- a/src/tensorflow.cc
+++ b/src/tensorflow.cc
@@ -2022,99 +2022,95 @@ ModelInstanceState::ProcessRequests(
     TRITONTF_TensorList* output_tensor_itr = output_tensors.get();
     for (const auto& name : model_output_names) {
       TRITONTF_Tensor* output_tensor = output_tensor_itr->tensor_;
+      output_tensor_itr = output_tensor_itr->next_;
 
       // For certain input data, the model can return an empty tensor
-      // as output. Make sure the output is available before trying
-      // to copy it out.
-      if (TRITONTF_TensorData(output_tensor) != nullptr) {
-        const BatchOutput* batch_output =
-            StateForModel()->FindBatchOutput(name);
-        if (batch_output == nullptr) {
-          TRITONTF_DataType tf_datatype =
-              TRITONTF_TensorDataType(output_tensor);
-          TRITONTF_Shape* tf_shape = TRITONTF_TensorShape(output_tensor);
+      // as output. We are skipping attaching such output in the
+      // response.
+      if (TRITONTF_TensorData(output_tensor) == nullptr) {
+        continue;
+      }
 
-          const TRITONSERVER_DataType datatype = ConvertDataType(tf_datatype);
+      const BatchOutput* batch_output = StateForModel()->FindBatchOutput(name);
+      if (batch_output == nullptr) {
+        TRITONTF_DataType tf_datatype = TRITONTF_TensorDataType(output_tensor);
+        TRITONTF_Shape* tf_shape = TRITONTF_TensorShape(output_tensor);
 
-          // batchn_shape holds the shape of the entire tensor batch, but
-          // is overwritten below and used as the shape for each response
-          // output.
-          std::vector<int64_t> batchn_shape;
-          batchn_shape.reserve(tf_shape->rank_);
-          for (size_t itr = 0; itr < tf_shape->rank_; itr++) {
-            const int64_t dim = tf_shape->dims_[itr];
-            batchn_shape.push_back(dim);
-          }
+        const TRITONSERVER_DataType datatype = ConvertDataType(tf_datatype);
 
-          // Custom handling for string/bytes tensor...
-          if (datatype == TRITONSERVER_TYPE_BYTES) {
-            size_t tensor_offset = 0;
+        // batchn_shape holds the shape of the entire tensor batch, but
+        // is overwritten below and used as the shape for each response
+        // output.
+        std::vector<int64_t> batchn_shape;
+        batchn_shape.reserve(tf_shape->rank_);
+        for (size_t itr = 0; itr < tf_shape->rank_; itr++) {
+          const int64_t dim = tf_shape->dims_[itr];
+          batchn_shape.push_back(dim);
+        }
 
-            for (size_t idx = 0; idx < responses.size(); idx++) {
-              auto& request = requests[idx];
-              auto& response = responses[idx];
+        // Custom handling for string/bytes tensor...
+        if (datatype == TRITONSERVER_TYPE_BYTES) {
+          size_t tensor_offset = 0;
 
-              if (max_batch_size != 0) {
-                // [TODO] remember some input properties on the first call
-                TRITONBACKEND_Input* input;
-                TRITONBACKEND_RequestInputByIndex(
-                    request, 0 /* index*/, &input);
-                const int64_t* shape;
-                TRITONBACKEND_InputProperties(
-                    input, nullptr, nullptr, &shape, nullptr, nullptr, nullptr);
-                batchn_shape[0] = shape[0];
-              }
+          for (size_t idx = 0; idx < responses.size(); idx++) {
+            auto& request = requests[idx];
+            auto& response = responses[idx];
 
-              const size_t tensor_element_cnt = GetElementCount(batchn_shape);
-
-              // Only need an response tensor for requested outputs.
-              if ((response != nullptr) &&
-                  (request_required_outputs[idx].find(name) !=
-                   request_required_outputs[idx].end())) {
-                TRITONBACKEND_Output* response_output;
-                RESPOND_AND_SET_NULL_IF_ERROR(
-                    &response,
-                    TRITONBACKEND_ResponseOutput(
-                        response, &response_output, name.c_str(), datatype,
-                        batchn_shape.data(), batchn_shape.size()));
-                string_buffer.emplace_back(new std::string());
-                cuda_copy |= SetStringOutputBuffer(
-                    output_tensor, &response, response_output,
-                    tensor_element_cnt, tensor_offset, CudaStream(),
-                    string_buffer.back().get());
-              }
-
-              tensor_offset += tensor_element_cnt;
+            if (max_batch_size != 0) {
+              // [TODO] remember some input properties on the first call
+              TRITONBACKEND_Input* input;
+              TRITONBACKEND_RequestInputByIndex(request, 0 /* index*/, &input);
+              const int64_t* shape;
+              TRITONBACKEND_InputProperties(
+                  input, nullptr, nullptr, &shape, nullptr, nullptr, nullptr);
+              batchn_shape[0] = shape[0];
             }
+
+            const size_t tensor_element_cnt = GetElementCount(batchn_shape);
+
+            // Only need an response tensor for requested outputs.
+            if ((response != nullptr) &&
+                (request_required_outputs[idx].find(name) !=
+                 request_required_outputs[idx].end())) {
+              TRITONBACKEND_Output* response_output;
+              RESPOND_AND_SET_NULL_IF_ERROR(
+                  &response,
+                  TRITONBACKEND_ResponseOutput(
+                      response, &response_output, name.c_str(), datatype,
+                      batchn_shape.data(), batchn_shape.size()));
+              string_buffer.emplace_back(new std::string());
+              cuda_copy |= SetStringOutputBuffer(
+                  output_tensor, &response, response_output, tensor_element_cnt,
+                  tensor_offset, CudaStream(), string_buffer.back().get());
+            }
+
+            tensor_offset += tensor_element_cnt;
           }
-          // Use the responder for non-STRING datatype...
-          else {  // datatype != DataType::TYPE_STRING
-            responder.ProcessTensor(
-                name, datatype, batchn_shape,
-                TRITONTF_TensorData(output_tensor),
-                (TRITONTF_TensorIsGPUTensor(output_tensor))
-                    ? TRITONSERVER_MEMORY_GPU
-                    : TRITONSERVER_MEMORY_CPU,
-                (TRITONTF_TensorIsGPUTensor(output_tensor)) ? DeviceId() : 0);
-          }
-        } else {
-          responder.ProcessBatchOutput(
-              name, *batch_output, TRITONTF_TensorData(output_tensor),
+        }
+        // Use the responder for non-STRING datatype...
+        else {  // datatype != DataType::TYPE_STRING
+          responder.ProcessTensor(
+              name, datatype, batchn_shape, TRITONTF_TensorData(output_tensor),
               (TRITONTF_TensorIsGPUTensor(output_tensor))
                   ? TRITONSERVER_MEMORY_GPU
                   : TRITONSERVER_MEMORY_CPU,
               (TRITONTF_TensorIsGPUTensor(output_tensor)) ? DeviceId() : 0);
         }
-
-        LOG_MESSAGE(
-            TRITONSERVER_LOG_VERBOSE,
-            (std::string("TRITONBACKEND_ModelExecute: output '") + name +
-             "' is GPU tensor: " +
-             ((TRITONTF_TensorIsGPUTensor(output_tensor)) ? "true" : "false"))
-                .c_str());
-
+      } else {
+        responder.ProcessBatchOutput(
+            name, *batch_output, TRITONTF_TensorData(output_tensor),
+            (TRITONTF_TensorIsGPUTensor(output_tensor))
+                ? TRITONSERVER_MEMORY_GPU
+                : TRITONSERVER_MEMORY_CPU,
+            (TRITONTF_TensorIsGPUTensor(output_tensor)) ? DeviceId() : 0);
       }
-      output_tensor_itr = output_tensor_itr->next_;
+
+      LOG_MESSAGE(
+          TRITONSERVER_LOG_VERBOSE,
+          (std::string("TRITONBACKEND_ModelExecute: output '") + name +
+           "' is GPU tensor: " +
+           ((TRITONTF_TensorIsGPUTensor(output_tensor)) ? "true" : "false"))
+              .c_str());
     }
 
     // Finalize and wait for any pending buffer copies.

--- a/src/tensorflow.cc
+++ b/src/tensorflow.cc
@@ -2113,8 +2113,8 @@ ModelInstanceState::ProcessRequests(
              ((TRITONTF_TensorIsGPUTensor(output_tensor)) ? "true" : "false"))
                 .c_str());
 
-        output_tensor_itr = output_tensor_itr->next_;
       }
+      output_tensor_itr = output_tensor_itr->next_;
     }
 
     // Finalize and wait for any pending buffer copies.

--- a/src/tensorflow.cc
+++ b/src/tensorflow.cc
@@ -2023,6 +2023,9 @@ ModelInstanceState::ProcessRequests(
     for (const auto& name : model_output_names) {
       TRITONTF_Tensor* output_tensor = output_tensor_itr->tensor_;
 
+      // For certain input data, the model can return an empty tensor
+      // as output. Make sure the output is available before trying
+      // to copy it out.
       if (TRITONTF_TensorData(output_tensor) != nullptr) {
         const BatchOutput* batch_output =
             StateForModel()->FindBatchOutput(name);

--- a/src/tensorflow.cc
+++ b/src/tensorflow.cc
@@ -2022,95 +2022,116 @@ ModelInstanceState::ProcessRequests(
     TRITONTF_TensorList* output_tensor_itr = output_tensors.get();
     for (const auto& name : model_output_names) {
       TRITONTF_Tensor* output_tensor = output_tensor_itr->tensor_;
-      output_tensor_itr = output_tensor_itr->next_;
 
       // For certain input data, the model can return an empty tensor
       // as output. We are skipping attaching such output in the
       // response.
       if (TRITONTF_TensorData(output_tensor) == nullptr) {
-        continue;
-      }
-
-      const BatchOutput* batch_output = StateForModel()->FindBatchOutput(name);
-      if (batch_output == nullptr) {
         TRITONTF_DataType tf_datatype = TRITONTF_TensorDataType(output_tensor);
-        TRITONTF_Shape* tf_shape = TRITONTF_TensorShape(output_tensor);
-
         const TRITONSERVER_DataType datatype = ConvertDataType(tf_datatype);
 
-        // batchn_shape holds the shape of the entire tensor batch, but
-        // is overwritten below and used as the shape for each response
-        // output.
-        std::vector<int64_t> batchn_shape;
-        batchn_shape.reserve(tf_shape->rank_);
-        for (size_t itr = 0; itr < tf_shape->rank_; itr++) {
-          const int64_t dim = tf_shape->dims_[itr];
-          batchn_shape.push_back(dim);
-        }
-
-        // Custom handling for string/bytes tensor...
-        if (datatype == TRITONSERVER_TYPE_BYTES) {
-          size_t tensor_offset = 0;
-
-          for (size_t idx = 0; idx < responses.size(); idx++) {
-            auto& request = requests[idx];
-            auto& response = responses[idx];
-
-            if (max_batch_size != 0) {
-              // [TODO] remember some input properties on the first call
-              TRITONBACKEND_Input* input;
-              TRITONBACKEND_RequestInputByIndex(request, 0 /* index*/, &input);
-              const int64_t* shape;
-              TRITONBACKEND_InputProperties(
-                  input, nullptr, nullptr, &shape, nullptr, nullptr, nullptr);
-              batchn_shape[0] = shape[0];
-            }
-
-            const size_t tensor_element_cnt = GetElementCount(batchn_shape);
-
-            // Only need an response tensor for requested outputs.
-            if ((response != nullptr) &&
-                (request_required_outputs[idx].find(name) !=
-                 request_required_outputs[idx].end())) {
-              TRITONBACKEND_Output* response_output;
-              RESPOND_AND_SET_NULL_IF_ERROR(
-                  &response,
-                  TRITONBACKEND_ResponseOutput(
-                      response, &response_output, name.c_str(), datatype,
-                      batchn_shape.data(), batchn_shape.size()));
-              string_buffer.emplace_back(new std::string());
-              cuda_copy |= SetStringOutputBuffer(
-                  output_tensor, &response, response_output, tensor_element_cnt,
-                  tensor_offset, CudaStream(), string_buffer.back().get());
-            }
-
-            tensor_offset += tensor_element_cnt;
+        for (size_t idx = 0; idx < responses.size(); idx++) {
+          auto& response = responses[idx];
+          if ((response != nullptr) &&
+              (request_required_outputs[idx].find(name) !=
+               request_required_outputs[idx].end())) {
+            TRITONBACKEND_Output* response_output;
+            std::vector<int64_t> empty_shape;
+            RESPOND_AND_SET_NULL_IF_ERROR(
+                &response,
+                TRITONBACKEND_ResponseOutput(
+                    response, &response_output, name.c_str(), datatype,
+                    empty_shape.data(), empty_shape.size()));
           }
         }
-        // Use the responder for non-STRING datatype...
-        else {  // datatype != DataType::TYPE_STRING
-          responder.ProcessTensor(
-              name, datatype, batchn_shape, TRITONTF_TensorData(output_tensor),
+      } else {
+        const BatchOutput* batch_output =
+            StateForModel()->FindBatchOutput(name);
+        if (batch_output == nullptr) {
+          TRITONTF_DataType tf_datatype =
+              TRITONTF_TensorDataType(output_tensor);
+          TRITONTF_Shape* tf_shape = TRITONTF_TensorShape(output_tensor);
+
+          const TRITONSERVER_DataType datatype = ConvertDataType(tf_datatype);
+
+          // batchn_shape holds the shape of the entire tensor batch, but
+          // is overwritten below and used as the shape for each response
+          // output.
+          std::vector<int64_t> batchn_shape;
+          batchn_shape.reserve(tf_shape->rank_);
+          for (size_t itr = 0; itr < tf_shape->rank_; itr++) {
+            const int64_t dim = tf_shape->dims_[itr];
+            batchn_shape.push_back(dim);
+          }
+
+          // Custom handling for string/bytes tensor...
+          if (datatype == TRITONSERVER_TYPE_BYTES) {
+            size_t tensor_offset = 0;
+
+            for (size_t idx = 0; idx < responses.size(); idx++) {
+              auto& request = requests[idx];
+              auto& response = responses[idx];
+
+              if (max_batch_size != 0) {
+                // [TODO] remember some input properties on the first call
+                TRITONBACKEND_Input* input;
+                TRITONBACKEND_RequestInputByIndex(
+                    request, 0 /* index*/, &input);
+                const int64_t* shape;
+                TRITONBACKEND_InputProperties(
+                    input, nullptr, nullptr, &shape, nullptr, nullptr, nullptr);
+                batchn_shape[0] = shape[0];
+              }
+
+              const size_t tensor_element_cnt = GetElementCount(batchn_shape);
+
+              // Only need an response tensor for requested outputs.
+              if ((response != nullptr) &&
+                  (request_required_outputs[idx].find(name) !=
+                   request_required_outputs[idx].end())) {
+                TRITONBACKEND_Output* response_output;
+                RESPOND_AND_SET_NULL_IF_ERROR(
+                    &response,
+                    TRITONBACKEND_ResponseOutput(
+                        response, &response_output, name.c_str(), datatype,
+                        batchn_shape.data(), batchn_shape.size()));
+                string_buffer.emplace_back(new std::string());
+                cuda_copy |= SetStringOutputBuffer(
+                    output_tensor, &response, response_output,
+                    tensor_element_cnt, tensor_offset, CudaStream(),
+                    string_buffer.back().get());
+              }
+
+              tensor_offset += tensor_element_cnt;
+            }
+          }
+          // Use the responder for non-STRING datatype...
+          else {  // datatype != DataType::TYPE_STRING
+            responder.ProcessTensor(
+                name, datatype, batchn_shape,
+                TRITONTF_TensorData(output_tensor),
+                (TRITONTF_TensorIsGPUTensor(output_tensor))
+                    ? TRITONSERVER_MEMORY_GPU
+                    : TRITONSERVER_MEMORY_CPU,
+                (TRITONTF_TensorIsGPUTensor(output_tensor)) ? DeviceId() : 0);
+          }
+        } else {
+          responder.ProcessBatchOutput(
+              name, *batch_output, TRITONTF_TensorData(output_tensor),
               (TRITONTF_TensorIsGPUTensor(output_tensor))
                   ? TRITONSERVER_MEMORY_GPU
                   : TRITONSERVER_MEMORY_CPU,
               (TRITONTF_TensorIsGPUTensor(output_tensor)) ? DeviceId() : 0);
         }
-      } else {
-        responder.ProcessBatchOutput(
-            name, *batch_output, TRITONTF_TensorData(output_tensor),
-            (TRITONTF_TensorIsGPUTensor(output_tensor))
-                ? TRITONSERVER_MEMORY_GPU
-                : TRITONSERVER_MEMORY_CPU,
-            (TRITONTF_TensorIsGPUTensor(output_tensor)) ? DeviceId() : 0);
-      }
 
-      LOG_MESSAGE(
-          TRITONSERVER_LOG_VERBOSE,
-          (std::string("TRITONBACKEND_ModelExecute: output '") + name +
-           "' is GPU tensor: " +
-           ((TRITONTF_TensorIsGPUTensor(output_tensor)) ? "true" : "false"))
-              .c_str());
+        LOG_MESSAGE(
+            TRITONSERVER_LOG_VERBOSE,
+            (std::string("TRITONBACKEND_ModelExecute: output '") + name +
+             "' is GPU tensor: " +
+             ((TRITONTF_TensorIsGPUTensor(output_tensor)) ? "true" : "false"))
+                .c_str());
+      }
+      output_tensor_itr = output_tensor_itr->next_;
     }
 
     // Finalize and wait for any pending buffer copies.


### PR DESCRIPTION
On the customer provided model with certain inputs:

### Before
Server crashes with the following backtrace:

```
#0  __memmove_avx_unaligned_erms () at ../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:319
#1  0x00007fffe950dacd in triton::backend::CopyBuffer (msg="probability", src_memory_type=TRITONSERVER_MEMORY_CPU, src_memory_type_id=0, dst_memory_type=TRITONSERVER_MEMORY_CPU, dst_memory_type_id=0, 
    byte_size=4, src=0x0, dst=0x7ffbb47893c0, cuda_stream=0x7fff983505d0, cuda_used=0x7ffcbbffa599, copy_on_stream=false)
    at /tmp/tritonbuild/tensorflow1/build/_deps/repo-backend-src/src/backend_common.cc:663
#2  0x00007fffe9532f0d in triton::backend::BackendOutputResponder::SetFixedSizeBuffer (this=0x7ffcbbffae40, response=0x7ffbc0002c80, response_output_or_state=0x7ffbc0003010, output_name="probability", 
    tensor_byte_size=4, tensor_offset=0, tensor_buffer=0x0, tensor_memory_type=TRITONSERVER_MEMORY_CPU, tensor_memory_type_id=0, use_pinned_memory_type=TRITONSERVER_MEMORY_GPU, state=false)
    at /tmp/tritonbuild/tensorflow1/build/_deps/repo-backend-src/src/backend_output_responder.cc:317
#3  0x00007fffe953195b in triton::backend::BackendOutputResponder::ProcessTensor (this=0x7ffcbbffae40, output_name="probability", datatype=TRITONSERVER_TYPE_FP32, 
    batchn_shape=std::vector of length 2, capacity 2 = {...}, buffer=0x0, memory_type=TRITONSERVER_MEMORY_CPU, memory_type_id=0)
    at /tmp/tritonbuild/tensorflow1/build/_deps/repo-backend-src/src/backend_output_responder.cc:110
#4  0x00007fffe94d945b in triton::backend::tensorflow::ModelInstanceState::ProcessRequests (this=0x7fff98e7b070, requests=0x7ffbc0000b60, request_count=1)
    at /tmp/tritonbuild/tensorflow1/src/tensorflow.cc:2085
#5  0x00007fffe94de543 in triton::backend::tensorflow::TRITONBACKEND_ModelInstanceExecute (instance=0x7fff98ef3ca0, requests=0x7ffbc0000b60, request_count=1)
    at /tmp/tritonbuild/tensorflow1/src/tensorflow.cc:2413
#6  0x00007ffff6eb71da in triton::core::TritonModelInstance::Execute(std::vector<TRITONBACKEND_Request*, std::allocator<TRITONBACKEND_Request*> >&) ()
   from /opt/tritonserver/bin/../lib/libtritonserver.so
#7  0x00007ffff6eb7b97 in triton::core::TritonModelInstance::Schedule(std::vector<std::unique_ptr<triton::core::InferenceRequest, std::default_delete<triton::core::InferenceRequest> >, std::allocator<std::unique_ptr<triton::core::InferenceRequest, std::default_delete<triton::core::InferenceRequest> > > >&&, std::function<void ()> const&) () from /opt/tritonserver/bin/../lib/libtritonserver.so
#8  0x00007ffff6f73101 in triton::core::Payload::Execute(bool*) () from /opt/tritonserver/bin/../lib/libtritonserver.so
#9  0x00007ffff6eb1067 in triton::core::TritonModelInstance::TritonBackendThread::BackendThread(int, int) () from /opt/tritonserver/bin/../lib/libtritonserver.so
#10 0x00007ffff69f8de4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#11 0x00007ffff7c01609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#12 0x00007ffff66e3163 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

### After

Server does not crash and client receives data as given by the TF savedmodel.

Server response for **failing** input data:
```
$ python3 test.py 
{'model_name': 'test_model', 'model_version': '0', 'outputs': []}
{'model_stats': [{'name': 'test_model', 'version': '0', 'last_inference': 1651179554061, 'inference_count': 3, 'execution_count': 3, 'inference_stats': {'success': {'count': 3, 'ns': 6724185605}, 'fail': {'count': 0, 'ns': 0}, 'queue': {'count': 3, 'ns': 215987}, 'compute_input': {'count': 3, 'ns': 3188159}, 'compute_infer': {'count': 3, 'ns': 6720544444}, 'compute_output': {'count': 3, 'ns': 58268}, 'cache_hit': {'count': 0, 'ns': 0}, 'cache_miss': {'count': 0, 'ns': 0}}, 'batch_stats': [{'batch_size': 1, 'compute_input': {'count': 3, 'ns': 3188159}, 'compute_infer': {'count': 3, 'ns': 6720544444}, 'compute_output': {'count': 3, 'ns': 58268}}]}]}
```
Model output for **failing** input data: `[]`

Server response for **passing** input data:
```
$ python3 test.py 
{'model_name': 'test_model', 'model_version': '0', 'outputs': [{'name': 'test_output', 'datatype': 'FP32', 'shape': [1, 1], 'data': [1.0]}]}
{'model_stats': [{'name': 'test_model', 'version': '0', 'last_inference': 1651100666261, 'inference_count': 1, 'execution_count': 1, 'inference_stats': {'success': {'count': 1, 'ns': 6514144525}, 'fail': {'count': 0, 'ns': 0}, 'queue': {'count': 1, 'ns': 117052}, 'compute_input': {'count': 1, 'ns': 1271179}, 'compute_infer': {'count': 1, 'ns': 6512661239}, 'compute_output': {'count': 1, 'ns': 32670}, 'cache_hit': {'count': 0, 'ns': 0}, 'cache_miss': {'count': 0, 'ns': 0}}, 'batch_stats': [{'batch_size': 1, 'compute_input': {'count': 1, 'ns': 1271179}, 'compute_infer': {'count': 1, 'ns': 6512661239}, 'compute_output': {'count': 1, 'ns': 32670}}]}]}
```
Model output for **passing** input data: `[[1.]]`

TODO: Need to generate such model so that we can add test into our CI. I have opened a JIRA ticket for the same.(DLIS-3740)


