### PR TITLE
Tensorflow FixIO Refactor

### DIFF
--- a/src/tensorflow.cc
+++ b/src/tensorflow.cc
@@ -1162,6 +1162,14 @@ class AutoCompleteHelper {
   TRITONSERVER_Error* FixIOConfig(
       const TRITONTF_IOList* reference_list, const char* key);
 
+  TRITONSERVER_Error* FixIOConfigInputs(
+    const TRITONTF_IOList* reference_list);
+
+  TRITONSERVER_Error* FixIOConfigOutputs(
+    const TRITONTF_IOList* reference_list);
+
+  TRITONSERVER_Error* FillMissingValues(
+    TRITONTF_IO* io, triton::common::TritonJson::Value &config);
 
   ModelState* model_state_;
   std::unique_ptr<TRITONTF_Model, decltype(&TRITONTF_ModelDelete)>
@@ -1179,11 +1187,11 @@ AutoCompleteHelper::Fix()
 
   // Inputs
   const TRITONTF_IOList* inputs = TRITONTF_ModelInputs(tritontf_model_.get());
-  RETURN_IF_ERROR(FixIOConfig(inputs, "input"));
+  RETURN_IF_ERROR(FixIOConfigInputs(inputs));
 
   // Outputs
   const TRITONTF_IOList* outputs = TRITONTF_ModelOutputs(tritontf_model_.get());
-  RETURN_IF_ERROR(FixIOConfig(outputs, "output"));
+  RETURN_IF_ERROR(FixIOConfigOutputs(outputs));
 
   return nullptr;  // success
 }
@@ -1332,13 +1340,363 @@ AutoCompleteHelper::FixBatchingSupport()
   return nullptr;  // success
 }
 
+TRITONTF_IO* FindModelIOByName(const char* name, const std::vector<const TRITONTF_IOList*> list)
+{
+  if (name == nullptr) {
+    return nullptr;
+  }
+
+  for (const auto item : list) {
+    TRITONTF_IO* io = item->io_;
+    if (!strcmp(name, io->name_)) {
+      return io;
+    }
+  } 
+
+  return nullptr;
+}
+
+TRITONTF_IO* FindModelIOByName(const char* name, const TRITONTF_IOList* list)
+{
+  if (name == nullptr) {
+    return nullptr;
+  }
+
+  while(list) {
+    TRITONTF_IO* io = list->io_;
+    if (!strcmp(name, io->name_)) {
+      return io;
+    }
+    list = list->next_;
+  } 
+
+  return nullptr;
+}
+
+
+TRITONSERVER_Error* AutoCompleteHelper::FillMissingValues(
+  TRITONTF_IO* io, triton::common::TritonJson::Value &config)
+{
+  //nocheckin
+  triton::common::TritonJson::WriteBuffer json_buffer;
+
+  json_buffer.Clear();
+  config.PrettyWriteValue(&json_buffer);
+  LOG_MESSAGE(TRITONSERVER_LOG_INFO,
+    (std::string("OLD CONFIG: \n") + json_buffer.Contents()).c_str());
+
+
+  triton::common::TritonJson::Value tmp(
+    model_state_->ModelConfig(),
+    triton::common::TritonJson::ValueType::OBJECT);
+
+  // triton::common::TritonJson::Value auto_complete_io(
+  //   model_state_->ModelConfig(),
+  //   triton::common::TritonJson::ValueType::OBJECT);
+  
+  // check data_type
+  bool found_config_data_type = config.Find("data_type", &tmp);
+  if (!found_config_data_type) {
+    //use the model data type
+    config.AddString("data_type", ConvertToModelConfigString(io->data_type_));
+  }
+
+  // check dims
+  bool found_dims = config.Find("dims", &tmp);
+  if (!found_dims) {
+    RETURN_ERROR_IF_TRUE(
+        io->shape_->rank_ == 0, TRITONSERVER_ERROR_INVALID_ARG,
+        std::string(
+            "Unable to autofill for '" + model_state_->Name() +
+            "': the rank of model tensor '" + io->name_ +
+            "' is 0 and dimensions are not defined");
+    // The model signature supports batching then the first
+    // dimension is -1 and should not appear in the model
+    // configuration 'dims' that we are creating.
+    triton::common::TritonJson::Value dims(
+      model_state_->ModelConfig(),
+      triton::common::TritonJson::ValueType::ARRAY);
+
+    for (size_t i = (model_support_batching_ ? 1 : 0); i < io->shape_->rank_;
+         ++i) {
+      RETURN_IF_ERROR(dims.AppendInt(io->shape_->dims_[i]));
+    }  
+    if (dims.ArraySize() == 0) {
+      RETURN_IF_ERROR(dims.AppendInt(1));
+      triton::common::TritonJson::Value reshape(
+          model_state_->ModelConfig(),
+          triton::common::TritonJson::ValueType::OBJECT);
+      triton::common::TritonJson::Value reshape_dims(
+          model_state_->ModelConfig(),
+          triton::common::TritonJson::ValueType::ARRAY);
+      RETURN_IF_ERROR(reshape.Add("shape", std::move(reshape_dims)));
+      RETURN_IF_ERROR(config.Add("reshape", std::move(reshape)));
+    }
+    RETURN_IF_ERROR(config.Add("dims", std::move(dims)));
+  }
+  // json_buffer.Clear();
+  // auto_complete_io.PrettyWriteValue(&json_buffer);
+  // LOG_MESSAGE(TRITONSERVER_LOG_INFO,
+  //   (std::string("FILLED OUT AUTOCOMPLETE: \n") + json_buffer.Contents()).c_str());
+  
+
+  json_buffer.Clear();
+  config.PrettyWriteValue(&json_buffer);
+  LOG_MESSAGE(TRITONSERVER_LOG_INFO,
+    (std::string("NEW CONFIG: \n") + json_buffer.Contents()).c_str());
+
+  return nullptr;   // Success
+}
+
+void RemoveFromListByName(const char* name, std::vector<const TRITONTF_IOList*>& list)
+{
+  for (size_t i = 0; i < list.size(); ++i) {
+    const TRITONTF_IOList* current = list.at(i);
+    if (!strcmp(name, current->io_->name_)) {
+      std::stringstream ss;
+      ss << current;
+      LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("deleting ptr: ") + ss.str()).c_str());
+      list.erase(list.begin() + i);      
+      return;
+    }
+  }
+}
+
+//deprecated
+/*
+void ClearIOCopy(std::vector<TRITONTF_IOList*>& list) 
+{
+  TRITONTF_IOList* current = list;
+  TRITONTF_IOList* next = current->next_;
+  while(current != nullptr) {
+    std::stringstream ss;
+    ss << current;
+    LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("deleting ptr: ") + ss.str()).c_str());
+    current->io_ = nullptr;
+    current->next_ = nullptr;
+    delete current;
+    
+    current = next;
+    next = current->next_;
+  }
+}
+*/
+std::vector<const TRITONTF_IOList*> CopyList(const TRITONTF_IOList* list)
+{
+  std::vector<const TRITONTF_IOList*> copy;
+  if (list == nullptr) {
+    return copy;
+  }
+
+  while (list != nullptr) {
+    copy.push_back(list);
+    list = list->next_;
+  }
+
+  return copy;
+}
+
+TRITONSERVER_Error* 
+AutoCompleteHelper::FixIOConfigInputs(
+  const TRITONTF_IOList* reference_list) 
+{
+  LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("FIXING INPUTS")).c_str());
+  //nocheckin
+  triton::common::TritonJson::WriteBuffer json_buffer;
+
+  triton::common::TritonJson::Value ios;
+  model_state_->ModelConfig().Find("input", &ios);
+
+  json_buffer.Clear();
+  ios.PrettyWriteValue(&json_buffer);
+  LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("IOS: \n") + json_buffer.Contents()).c_str());
+
+  // Input names must all be defined and match the user provided config.
+  // - If there is an input from the model which is not in config.pbtxt
+  //   then we try to autocomplete it. 
+  // - If there is an input in the config.pbtxt
+  //   which is not in the model then we throw an error.
+  // Iterate through the user provided ios since we expect this to be 
+  std::vector<const TRITONTF_IOList*> reference_list_copy = CopyList(reference_list);
+
+  std::stringstream ss_copy;
+  
+  for(const auto item : reference_list_copy){
+    ss_copy << item << ", ";
+  }
+  LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("copy ptrs: ") + ss_copy.str()).c_str());
+
+  std::stringstream ss_base;
+  const TRITONTF_IOList* debug_ptr = reference_list;
+  while (debug_ptr != nullptr) {
+    ss_base << debug_ptr << ", ";
+    debug_ptr = debug_ptr->next_;
+  }
+  LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("base ptrs: ") + ss_base.str()).c_str());
+
+
+  triton::common::TritonJson::Value current_io(
+      model_state_->ModelConfig(),
+      triton::common::TritonJson::ValueType::OBJECT);
+  for (size_t i = 0; i < ios.ArraySize(); ++i) {
+    ios.IndexAsObject(i, &current_io);
+
+    triton::common::TritonJson::Value current_name(
+      model_state_->ModelConfig(),
+      triton::common::TritonJson::ValueType::OBJECT);
+    std::string config_name;
+    RETURN_IF_ERROR(current_io.MemberAsString("name", &config_name));
+
+    TRITONTF_IO* io = FindModelIOByName(config_name.c_str(), reference_list_copy);
+    if (io == nullptr) {
+      TRITONSERVER_ErrorNew(TRITONSERVER_ERROR_INVALID_ARG, 
+        (std::string("Config file provided input name '") + config_name +
+        std::string("' but none found in loaded model '") +
+        model_state_->Name() + std::string("'.")).c_str());
+    }
+
+    TRITONSERVER_Error* err = FillMissingValues(io, current_io);
+    if (err) {
+      return err;
+    }
+
+    RemoveFromListByName(io->name_, reference_list_copy);
+  }
+  
+  for (size_t i = 0; i < reference_list_copy.size(); ++i) {
+    const TRITONTF_IOList* current = reference_list_copy.at(i);
+    TRITONTF_IO* io = current->io_;
+
+    triton::common::TritonJson::Value blank_value(
+      model_state_->ModelConfig(),
+      triton::common::TritonJson::ValueType::OBJECT);
+
+    TRITONSERVER_Error* err = FillMissingValues(io, blank_value);
+    if (err) {
+      return err;
+    }
+
+    ios.Append(std::move(blank_value));
+  }
+  
+  json_buffer.Clear();
+  ios.PrettyWriteValue(&json_buffer);
+  LOG_MESSAGE(TRITONSERVER_LOG_INFO, 
+    (std::string("FINAL INPUT IOS: \n") + json_buffer.Contents()).c_str());
+
+  // ClearIOCopy(reference_list_copy);
+  reference_list_copy.clear();
+
+  return nullptr;  // success 
+}
+
+TRITONSERVER_Error* 
+AutoCompleteHelper::FixIOConfigOutputs(
+  const TRITONTF_IOList* reference_list) 
+{
+  LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("FIXING OUTPUTS")).c_str());
+  //nocheckin
+  triton::common::TritonJson::WriteBuffer json_buffer;
+
+  triton::common::TritonJson::Value ios;
+  bool found_ios = model_state_->ModelConfig().Find("output", &ios);
+
+  json_buffer.Clear();
+  ios.PrettyWriteValue(&json_buffer);
+  LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("IOS: \n") + json_buffer.Contents()).c_str());
+
+  // If output is empty or undefined then we want to autocomplete this otherwise 
+  // we only want to check the defined outputs
+  bool should_auto_complete_output = (!found_ios || ios.ArraySize() == 0);
+  if (should_auto_complete_output) {
+      triton::common::TritonJson::Value auto_complete_ios(
+      model_state_->ModelConfig(),
+      triton::common::TritonJson::ValueType::ARRAY);
+    for (const TRITONTF_IOList* itr = reference_list; itr != nullptr;
+        itr = itr->next_) {
+      TRITONTF_IO* io = itr->io_;
+
+      triton::common::TritonJson::Value auto_complete_io(
+          model_state_->ModelConfig(),
+          triton::common::TritonJson::ValueType::OBJECT);
+      RETURN_IF_ERROR(auto_complete_io.AddString("name", io->name_));
+      RETURN_IF_ERROR(auto_complete_io.AddString(
+          "data_type", ConvertToModelConfigString(io->data_type_)));
+      triton::common::TritonJson::Value dims(
+          model_state_->ModelConfig(),
+          triton::common::TritonJson::ValueType::ARRAY);
+      RETURN_ERROR_IF_TRUE(
+          io->shape_->rank_ == 0, TRITONSERVER_ERROR_INVALID_ARG,
+          std::string(
+              "Unable to autofill for '" + model_state_->Name() +
+              "': the rank of model tensor '" + io->name_ +
+              "' is 0 which is not supported"));
+      // The model signature supports batching then the first
+      // dimension is -1 and should not appear in the model
+      // configuration 'dims' that we are creating.
+      for (size_t i = (model_support_batching_ ? 1 : 0); i < io->shape_->rank_;
+          ++i) {
+        RETURN_IF_ERROR(dims.AppendInt(io->shape_->dims_[i]));
+      }
+
+      // If io dims are empty then must use a reshape for the
+      // io, since 'dims' is not allowed to be empty.
+      if (dims.ArraySize() == 0) {
+        RETURN_IF_ERROR(dims.AppendInt(1));
+        triton::common::TritonJson::Value reshape(
+            model_state_->ModelConfig(),
+            triton::common::TritonJson::ValueType::OBJECT);
+        triton::common::TritonJson::Value reshape_dims(
+            model_state_->ModelConfig(),
+            triton::common::TritonJson::ValueType::ARRAY);
+        RETURN_IF_ERROR(reshape.Add("shape", std::move(reshape_dims)));
+        RETURN_IF_ERROR(auto_complete_io.Add("reshape", std::move(reshape)));
+      }
+      RETURN_IF_ERROR(auto_complete_io.Add("dims", std::move(dims)));
+      RETURN_IF_ERROR(auto_complete_ios.Append(std::move(auto_complete_io)));
+    }
+    if (found_ios) {
+      ios.Swap(auto_complete_ios);
+    } else {
+      model_state_->ModelConfig().Add("output", std::move(auto_complete_ios));
+    }
+  } else {
+    // don't need to copy here since we don't need to keep track of what 
+    // we need to check at the end.
+    triton::common::TritonJson::Value current_io(
+      model_state_->ModelConfig(),
+      triton::common::TritonJson::ValueType::OBJECT);
+    for (size_t i = 0; i < ios.ArraySize(); ++i) {
+      ios.IndexAsObject(i, &current_io);
+
+      std::string output_name;
+      RETURN_IF_ERROR(current_io.MemberAsString("name", &output_name));
+
+      TRITONTF_IO* io = FindModelIOByName(output_name.c_str(), reference_list);
+
+      // may want to rethink the swap in this
+      FillMissingValues(io, current_io);
+    }
+  }
+  return nullptr;  // success
+}
+
+
 TRITONSERVER_Error*
 AutoCompleteHelper::FixIOConfig(
     const TRITONTF_IOList* reference_list, const char* key)
 {
+
+  //nocheckin
+  triton::common::TritonJson::WriteBuffer json_buffer;
+
   // Replace I/O even if inputs / outputs are specified in config.
   triton::common::TritonJson::Value ios;
   bool found_ios = model_state_->ModelConfig().Find(key, &ios);
+
+  json_buffer.Clear();
+  ios.PrettyWriteValue(&json_buffer);
+  LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("IOS: \n") + json_buffer.Contents()).c_str());
 
   triton::common::TritonJson::Value auto_complete_ios(
       model_state_->ModelConfig(),
@@ -1429,36 +1787,51 @@ AutoCompleteHelper::FixIOConfig(
             triton::common::TritonJson::ValueType::OBJECT);
         ios.IndexAsObject(i, &current_io_object);
 
-        if (!using_ragged_batching_) {
-          triton::common::TritonJson::Value current_dims(
-              model_state_->ModelConfig(),
-              triton::common::TritonJson::ValueType::ARRAY);
-          current_io_object.Find("dims", &current_dims);
+        json_buffer.Clear();
+        current_io_object.PrettyWriteValue(&json_buffer);
+        LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("CURRENT_IO_OBJECT: \n") + json_buffer.Contents()).c_str());
 
-          if (model_support_batching_) {
-            RETURN_ERROR_IF_TRUE(
-                current_dims.ArraySize() != (io->shape_->rank_ - 1),
-                TRITONSERVER_ERROR_INVALID_ARG,
-                std::string(
-                    "Number of dimensions (" +
-                    std::to_string(current_dims.ArraySize()) +
-                    ") given for tensor " + io->name_ + " for model '" +
-                    model_state_->Name() +
-                    "' in configuration does not match the rank (" +
-                    std::to_string(io->shape_->rank_ - 1) +
-                    ") of the loaded model."));
-          } else {
-            RETURN_ERROR_IF_TRUE(
-                current_dims.ArraySize() != io->shape_->rank_,
-                TRITONSERVER_ERROR_INVALID_ARG,
-                std::string(
-                    "Number of dimensions (" +
-                    std::to_string(dims.ArraySize()) + ") given for tensor " +
-                    io->name_ + " for model '" + model_state_->Name() +
-                    "' in configuration does not match the rank (" +
-                    std::to_string(io->shape_->rank_) +
-                    ") of the loaded model."));
+        triton::common::TritonJson::Value current_dims(
+            model_state_->ModelConfig(),
+            triton::common::TritonJson::ValueType::ARRAY);
+        current_io_object.Find("dims", &current_dims);
+
+        json_buffer.Clear();
+        current_dims.PrettyWriteValue(&json_buffer);
+        LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("CURRENT_DIMS: \n") + json_buffer.Contents()).c_str());
+
+        size_t dims_size = dims.ArraySize();
+        size_t non_negative_dim_values = 0;
+        int64_t tmp;
+        for (size_t j = 0; j < dims_size; ++j) {
+          current_dims.IndexAsInt(j, &tmp);
+          if (tmp != -1) {
+            ++non_negative_dim_values;
           }
+        }
+        size_t adjusted_dims_size = (model_support_batching_ ? dims_size -1 : dims_size);
+        LOG_MESSAGE(TRITONSERVER_LOG_ERROR, (std::string("ADJUSTED_DIMS_SIZE: \n") + std::to_string(adjusted_dims_size)).c_str() );
+
+        if (model_support_batching_) {
+          RETURN_ERROR_IF_TRUE(
+              current_dims.ArraySize() != (io->shape_->rank_ - 1),
+              TRITONSERVER_ERROR_INVALID_ARG,
+              std::string(
+                  "Number of dimensions (" + std::to_string(dims.ArraySize()) +
+                  ") given for '" + model_state_->Name() +
+                  "' in configuration does not match the rank (" +
+                  std::to_string(io->shape_->rank_ - 1) +
+                  ")of the loaded model."));
+        } else {
+          RETURN_ERROR_IF_TRUE(
+              current_dims.ArraySize() != io->shape_->rank_,
+              TRITONSERVER_ERROR_INVALID_ARG,
+              std::string(
+                  "Number of dimensions (" + std::to_string(dims.ArraySize()) +
+                  ") given for '" + model_state_->Name() +
+                  "' in configuration does not match the rank (" +
+                  std::to_string(io->shape_->rank_) +
+                  ") of the loaded model."));
         }
       }
     } else {

--- a/src/tensorflow.cc
+++ b/src/tensorflow.cc
@@ -1168,8 +1168,6 @@ class AutoCompleteHelper {
 
   void CopyList(const TRITONTF_IOList* src, std::vector<const TRITONTF_IOList*>& dst);
 
-  bool IsEmptyIO(triton::common::TritonJson::Value& value);
-
   TRITONSERVER_Error* FillMissingValues(
       const TRITONTF_IO* io, triton::common::TritonJson::Value& config);
 
@@ -1342,16 +1340,6 @@ AutoCompleteHelper::FixBatchingSupport()
   return nullptr;  // success
 }
 
-bool
-AutoCompleteHelper::IsEmptyIO(triton::common::TritonJson::Value& io_config) {
-  std::vector<std::string> members;
-  io_config.Members(&members);
-  if (members.empty()){ 
-    return true;
-  }
-  return false;
-}
-
 TRITONSERVER_Error*
 AutoCompleteHelper::FillMissingValues(
     const TRITONTF_IO* io, triton::common::TritonJson::Value& io_config)
@@ -1360,7 +1348,7 @@ AutoCompleteHelper::FillMissingValues(
       model_state_->ModelConfig(),
       triton::common::TritonJson::ValueType::OBJECT);
 
-  bool is_empty_io = IsEmptyIO(io_config);
+  bool is_empty_io = io_config.Empty();
   if (!is_empty_io && !io_config.Find("name", &tmp)) {
     return TRITONSERVER_ErrorNew(
           TRITONSERVER_ERROR_INVALID_ARG,

--- a/src/tensorflow.cc
+++ b/src/tensorflow.cc
@@ -1159,17 +1159,17 @@ class AutoCompleteHelper {
 
  private:
   TRITONSERVER_Error* FixBatchingSupport();
-  TRITONSERVER_Error* FixIOConfig(
-      const TRITONTF_IOList* reference_list, const char* key);
+  TRITONSERVER_Error* FixIOConfigInputs(const TRITONTF_IOList* reference_list);
 
-  TRITONSERVER_Error* FixIOConfigInputs(
-    const TRITONTF_IOList* reference_list);
+  TRITONSERVER_Error* FixIOConfigOutputs(const TRITONTF_IOList* reference_list);
 
-  TRITONSERVER_Error* FixIOConfigOutputs(
-    const TRITONTF_IOList* reference_list);
+  void RemoveFromListByName(
+      const char* name, std::vector<const TRITONTF_IOList*>& list);
+
+  std::vector<const TRITONTF_IOList*> CopyList(const TRITONTF_IOList* list);
 
   TRITONSERVER_Error* FillMissingValues(
-    TRITONTF_IO* io, triton::common::TritonJson::Value &config);
+      TRITONTF_IO* io, triton::common::TritonJson::Value& config);
 
   ModelState* model_state_;
   std::unique_ptr<TRITONTF_Model, decltype(&TRITONTF_ModelDelete)>
@@ -1340,7 +1340,9 @@ AutoCompleteHelper::FixBatchingSupport()
   return nullptr;  // success
 }
 
-TRITONTF_IO* FindModelIOByName(const char* name, const std::vector<const TRITONTF_IOList*> list)
+TRITONTF_IO*
+FindModelIOByName(
+    const char* name, const std::vector<const TRITONTF_IOList*> list)
 {
   if (name == nullptr) {
     return nullptr;
@@ -1351,76 +1353,73 @@ TRITONTF_IO* FindModelIOByName(const char* name, const std::vector<const TRITONT
     if (!strcmp(name, io->name_)) {
       return io;
     }
-  } 
+  }
 
   return nullptr;
 }
 
-TRITONTF_IO* FindModelIOByName(const char* name, const TRITONTF_IOList* list)
+TRITONTF_IO*
+FindModelIOByName(const char* name, const TRITONTF_IOList* list)
 {
   if (name == nullptr) {
     return nullptr;
   }
 
-  while(list) {
+  while (list) {
     TRITONTF_IO* io = list->io_;
     if (!strcmp(name, io->name_)) {
       return io;
     }
     list = list->next_;
-  } 
+  }
 
   return nullptr;
 }
 
 
-TRITONSERVER_Error* AutoCompleteHelper::FillMissingValues(
-  TRITONTF_IO* io, triton::common::TritonJson::Value &config)
+TRITONSERVER_Error*
+AutoCompleteHelper::FillMissingValues(
+    TRITONTF_IO* io, triton::common::TritonJson::Value& config)
 {
-  //nocheckin
-  triton::common::TritonJson::WriteBuffer json_buffer;
-
-  json_buffer.Clear();
-  config.PrettyWriteValue(&json_buffer);
-  LOG_MESSAGE(TRITONSERVER_LOG_INFO,
-    (std::string("OLD CONFIG: \n") + json_buffer.Contents()).c_str());
-
-
   triton::common::TritonJson::Value tmp(
-    model_state_->ModelConfig(),
-    triton::common::TritonJson::ValueType::OBJECT);
+      model_state_->ModelConfig(),
+      triton::common::TritonJson::ValueType::OBJECT);
 
-  // triton::common::TritonJson::Value auto_complete_io(
-  //   model_state_->ModelConfig(),
-  //   triton::common::TritonJson::ValueType::OBJECT);
-  
-  // check data_type
-  bool found_config_data_type = config.Find("data_type", &tmp);
-  if (!found_config_data_type) {
-    //use the model data type
-    config.AddString("data_type", ConvertToModelConfigString(io->data_type_));
+  bool found_name = config.Find("name", &tmp);
+  if (!found_name) {
+    triton::common::TritonJson::Value name;
+    RETURN_IF_ERROR(config.AddString("name", io->name_));
   }
 
-  // check dims
+  bool found_config_data_type = config.Find("data_type", &tmp);
+  std::string data_type_str;
+  tmp.AsString(&data_type_str);
+  bool should_auto_complete_data_type =
+      !found_config_data_type || DataTypeIsInvalid(data_type_str);
+  if (should_auto_complete_data_type) {
+    config.SetString("data_type", ConvertToModelConfigString(io->data_type_));
+  }
+
   bool found_dims = config.Find("dims", &tmp);
-  if (!found_dims) {
+  bool should_auto_complete_dims = !found_dims || (tmp.ArraySize() == 0);
+  if (should_auto_complete_dims) {
     RETURN_ERROR_IF_TRUE(
         io->shape_->rank_ == 0, TRITONSERVER_ERROR_INVALID_ARG,
         std::string(
             "Unable to autofill for '" + model_state_->Name() +
             "': the rank of model tensor '" + io->name_ +
-            "' is 0 and dimensions are not defined");
+            "' is 0 and dimensions are not defined"));
     // The model signature supports batching then the first
     // dimension is -1 and should not appear in the model
     // configuration 'dims' that we are creating.
     triton::common::TritonJson::Value dims(
-      model_state_->ModelConfig(),
-      triton::common::TritonJson::ValueType::ARRAY);
+        model_state_->ModelConfig(),
+        triton::common::TritonJson::ValueType::ARRAY);
 
     for (size_t i = (model_support_batching_ ? 1 : 0); i < io->shape_->rank_;
          ++i) {
       RETURN_IF_ERROR(dims.AppendInt(io->shape_->dims_[i]));
-    }  
+    }
     if (dims.ArraySize() == 0) {
       RETURN_IF_ERROR(dims.AppendInt(1));
       triton::common::TritonJson::Value reshape(
@@ -1432,56 +1431,31 @@ TRITONSERVER_Error* AutoCompleteHelper::FillMissingValues(
       RETURN_IF_ERROR(reshape.Add("shape", std::move(reshape_dims)));
       RETURN_IF_ERROR(config.Add("reshape", std::move(reshape)));
     }
+
+    if (found_dims) {
+      RETURN_IF_ERROR(config.Remove("dims"));
+    }
     RETURN_IF_ERROR(config.Add("dims", std::move(dims)));
   }
-  // json_buffer.Clear();
-  // auto_complete_io.PrettyWriteValue(&json_buffer);
-  // LOG_MESSAGE(TRITONSERVER_LOG_INFO,
-  //   (std::string("FILLED OUT AUTOCOMPLETE: \n") + json_buffer.Contents()).c_str());
-  
 
-  json_buffer.Clear();
-  config.PrettyWriteValue(&json_buffer);
-  LOG_MESSAGE(TRITONSERVER_LOG_INFO,
-    (std::string("NEW CONFIG: \n") + json_buffer.Contents()).c_str());
-
-  return nullptr;   // Success
+  return nullptr;  // Success
 }
 
-void RemoveFromListByName(const char* name, std::vector<const TRITONTF_IOList*>& list)
+void
+AutoCompleteHelper::RemoveFromListByName(
+    const char* name, std::vector<const TRITONTF_IOList*>& list)
 {
   for (size_t i = 0; i < list.size(); ++i) {
     const TRITONTF_IOList* current = list.at(i);
     if (!strcmp(name, current->io_->name_)) {
-      std::stringstream ss;
-      ss << current;
-      LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("deleting ptr: ") + ss.str()).c_str());
-      list.erase(list.begin() + i);      
+      list.erase(list.begin() + i);
       return;
     }
   }
 }
 
-//deprecated
-/*
-void ClearIOCopy(std::vector<TRITONTF_IOList*>& list) 
-{
-  TRITONTF_IOList* current = list;
-  TRITONTF_IOList* next = current->next_;
-  while(current != nullptr) {
-    std::stringstream ss;
-    ss << current;
-    LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("deleting ptr: ") + ss.str()).c_str());
-    current->io_ = nullptr;
-    current->next_ = nullptr;
-    delete current;
-    
-    current = next;
-    next = current->next_;
-  }
-}
-*/
-std::vector<const TRITONTF_IOList*> CopyList(const TRITONTF_IOList* list)
+std::vector<const TRITONTF_IOList*>
+AutoCompleteHelper::CopyList(const TRITONTF_IOList* list)
 {
   std::vector<const TRITONTF_IOList*> copy;
   if (list == nullptr) {
@@ -1496,44 +1470,28 @@ std::vector<const TRITONTF_IOList*> CopyList(const TRITONTF_IOList* list)
   return copy;
 }
 
-TRITONSERVER_Error* 
-AutoCompleteHelper::FixIOConfigInputs(
-  const TRITONTF_IOList* reference_list) 
+TRITONSERVER_Error*
+AutoCompleteHelper::FixIOConfigInputs(const TRITONTF_IOList* reference_list)
 {
-  LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("FIXING INPUTS")).c_str());
-  //nocheckin
-  triton::common::TritonJson::WriteBuffer json_buffer;
-
   triton::common::TritonJson::Value ios;
   model_state_->ModelConfig().Find("input", &ios);
 
-  json_buffer.Clear();
-  ios.PrettyWriteValue(&json_buffer);
-  LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("IOS: \n") + json_buffer.Contents()).c_str());
-
   // Input names must all be defined and match the user provided config.
   // - If there is an input from the model which is not in config.pbtxt
-  //   then we try to autocomplete it. 
+  //   then we try to autocomplete it.
   // - If there is an input in the config.pbtxt
   //   which is not in the model then we throw an error.
-  // Iterate through the user provided ios since we expect this to be 
-  std::vector<const TRITONTF_IOList*> reference_list_copy = CopyList(reference_list);
-
-  std::stringstream ss_copy;
-  
-  for(const auto item : reference_list_copy){
-    ss_copy << item << ", ";
-  }
-  LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("copy ptrs: ") + ss_copy.str()).c_str());
-
-  std::stringstream ss_base;
-  const TRITONTF_IOList* debug_ptr = reference_list;
-  while (debug_ptr != nullptr) {
-    ss_base << debug_ptr << ", ";
-    debug_ptr = debug_ptr->next_;
-  }
-  LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("base ptrs: ") + ss_base.str()).c_str());
-
+  // Iterate through the user provided ios since we expect this to be
+  // well defined.
+  std::vector<const TRITONTF_IOList*> reference_list_copy =
+      CopyList(reference_list);
+  RETURN_ERROR_IF_TRUE(
+      ios.ArraySize() > reference_list_copy.size(),
+      TRITONSERVER_ERROR_INVALID_ARG,
+      (std::string("Config file specifies too many inputs, ") +
+       std::to_string(ios.ArraySize()) + std::string(", while loaded model '") +
+       model_state_->Name() + std::string("' specifies ") +
+       std::to_string(reference_list_copy.size())));
 
   triton::common::TritonJson::Value current_io(
       model_state_->ModelConfig(),
@@ -1542,18 +1500,18 @@ AutoCompleteHelper::FixIOConfigInputs(
     ios.IndexAsObject(i, &current_io);
 
     triton::common::TritonJson::Value current_name(
-      model_state_->ModelConfig(),
-      triton::common::TritonJson::ValueType::OBJECT);
+        model_state_->ModelConfig(),
+        triton::common::TritonJson::ValueType::OBJECT);
     std::string config_name;
     RETURN_IF_ERROR(current_io.MemberAsString("name", &config_name));
 
-    TRITONTF_IO* io = FindModelIOByName(config_name.c_str(), reference_list_copy);
-    if (io == nullptr) {
-      TRITONSERVER_ErrorNew(TRITONSERVER_ERROR_INVALID_ARG, 
+    TRITONTF_IO* io =
+        FindModelIOByName(config_name.c_str(), reference_list_copy);
+    RETURN_ERROR_IF_TRUE(
+        io == nullptr, TRITONSERVER_ERROR_INVALID_ARG,
         (std::string("Config file provided input name '") + config_name +
-        std::string("' but none found in loaded model '") +
-        model_state_->Name() + std::string("'.")).c_str());
-    }
+         std::string("' but none found in loaded model '") +
+         model_state_->Name() + std::string("'.")));
 
     TRITONSERVER_Error* err = FillMissingValues(io, current_io);
     if (err) {
@@ -1562,14 +1520,14 @@ AutoCompleteHelper::FixIOConfigInputs(
 
     RemoveFromListByName(io->name_, reference_list_copy);
   }
-  
+
   for (size_t i = 0; i < reference_list_copy.size(); ++i) {
     const TRITONTF_IOList* current = reference_list_copy.at(i);
     TRITONTF_IO* io = current->io_;
 
     triton::common::TritonJson::Value blank_value(
-      model_state_->ModelConfig(),
-      triton::common::TritonJson::ValueType::OBJECT);
+        model_state_->ModelConfig(),
+        triton::common::TritonJson::ValueType::OBJECT);
 
     TRITONSERVER_Error* err = FillMissingValues(io, blank_value);
     if (err) {
@@ -1578,42 +1536,26 @@ AutoCompleteHelper::FixIOConfigInputs(
 
     ios.Append(std::move(blank_value));
   }
-  
-  json_buffer.Clear();
-  ios.PrettyWriteValue(&json_buffer);
-  LOG_MESSAGE(TRITONSERVER_LOG_INFO, 
-    (std::string("FINAL INPUT IOS: \n") + json_buffer.Contents()).c_str());
-
-  // ClearIOCopy(reference_list_copy);
   reference_list_copy.clear();
 
-  return nullptr;  // success 
+  return nullptr;  // success
 }
 
-TRITONSERVER_Error* 
-AutoCompleteHelper::FixIOConfigOutputs(
-  const TRITONTF_IOList* reference_list) 
+TRITONSERVER_Error*
+AutoCompleteHelper::FixIOConfigOutputs(const TRITONTF_IOList* reference_list)
 {
-  LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("FIXING OUTPUTS")).c_str());
-  //nocheckin
-  triton::common::TritonJson::WriteBuffer json_buffer;
-
   triton::common::TritonJson::Value ios;
   bool found_ios = model_state_->ModelConfig().Find("output", &ios);
 
-  json_buffer.Clear();
-  ios.PrettyWriteValue(&json_buffer);
-  LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("IOS: \n") + json_buffer.Contents()).c_str());
-
-  // If output is empty or undefined then we want to autocomplete this otherwise 
+  // If output is empty or undefined then we want to autocomplete this otherwise
   // we only want to check the defined outputs
   bool should_auto_complete_output = (!found_ios || ios.ArraySize() == 0);
   if (should_auto_complete_output) {
-      triton::common::TritonJson::Value auto_complete_ios(
-      model_state_->ModelConfig(),
-      triton::common::TritonJson::ValueType::ARRAY);
+    triton::common::TritonJson::Value auto_complete_ios(
+        model_state_->ModelConfig(),
+        triton::common::TritonJson::ValueType::ARRAY);
     for (const TRITONTF_IOList* itr = reference_list; itr != nullptr;
-        itr = itr->next_) {
+         itr = itr->next_) {
       TRITONTF_IO* io = itr->io_;
 
       triton::common::TritonJson::Value auto_complete_io(
@@ -1635,7 +1577,7 @@ AutoCompleteHelper::FixIOConfigOutputs(
       // dimension is -1 and should not appear in the model
       // configuration 'dims' that we are creating.
       for (size_t i = (model_support_batching_ ? 1 : 0); i < io->shape_->rank_;
-          ++i) {
+           ++i) {
         RETURN_IF_ERROR(dims.AppendInt(io->shape_->dims_[i]));
       }
 
@@ -1661,11 +1603,10 @@ AutoCompleteHelper::FixIOConfigOutputs(
       model_state_->ModelConfig().Add("output", std::move(auto_complete_ios));
     }
   } else {
-    // don't need to copy here since we don't need to keep track of what 
-    // we need to check at the end.
+    // don't need to check what was processed at the end so no need to copy
     triton::common::TritonJson::Value current_io(
-      model_state_->ModelConfig(),
-      triton::common::TritonJson::ValueType::OBJECT);
+        model_state_->ModelConfig(),
+        triton::common::TritonJson::ValueType::OBJECT);
     for (size_t i = 0; i < ios.ArraySize(); ++i) {
       ios.IndexAsObject(i, &current_io);
 
@@ -1673,177 +1614,15 @@ AutoCompleteHelper::FixIOConfigOutputs(
       RETURN_IF_ERROR(current_io.MemberAsString("name", &output_name));
 
       TRITONTF_IO* io = FindModelIOByName(output_name.c_str(), reference_list);
+      RETURN_ERROR_IF_TRUE(
+          io == nullptr, TRITONSERVER_ERROR_INVALID_ARG,
+          (std::string("Config file provided output name '") + output_name +
+           std::string("' but none found in loaded model '") +
+           model_state_->Name() + std::string("'.")));
 
-      // may want to rethink the swap in this
       FillMissingValues(io, current_io);
     }
   }
-  return nullptr;  // success
-}
-
-
-TRITONSERVER_Error*
-AutoCompleteHelper::FixIOConfig(
-    const TRITONTF_IOList* reference_list, const char* key)
-{
-
-  //nocheckin
-  triton::common::TritonJson::WriteBuffer json_buffer;
-
-  // Replace I/O even if inputs / outputs are specified in config.
-  triton::common::TritonJson::Value ios;
-  bool found_ios = model_state_->ModelConfig().Find(key, &ios);
-
-  json_buffer.Clear();
-  ios.PrettyWriteValue(&json_buffer);
-  LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("IOS: \n") + json_buffer.Contents()).c_str());
-
-  triton::common::TritonJson::Value auto_complete_ios(
-      model_state_->ModelConfig(),
-      triton::common::TritonJson::ValueType::ARRAY);
-  for (const TRITONTF_IOList* itr = reference_list; itr != nullptr;
-       itr = itr->next_) {
-    TRITONTF_IO* io = itr->io_;
-
-    triton::common::TritonJson::Value auto_complete_io(
-        model_state_->ModelConfig(),
-        triton::common::TritonJson::ValueType::OBJECT);
-    RETURN_IF_ERROR(auto_complete_io.AddString("name", io->name_));
-    RETURN_IF_ERROR(auto_complete_io.AddString(
-        "data_type", ConvertToModelConfigString(io->data_type_)));
-    triton::common::TritonJson::Value dims(
-        model_state_->ModelConfig(),
-        triton::common::TritonJson::ValueType::ARRAY);
-
-    // look at the loaded config, if there is one, for a hint about the
-    // rank of the model.
-    if (io->shape_->rank_ == 0 && found_ios) {
-      // If rank is 0 then we have to rely on the provided config to determine
-      // the dimensions of the inputs/outputs
-      size_t io_size = ios.ArraySize();
-      RETURN_ERROR_IF_TRUE(
-          io_size == 0, TRITONSERVER_ERROR_INVALID_ARG,
-          std::string(
-              "Unable to autofill for '" + model_state_->Name() +
-              "': the rank of model tensor '" + io->name_ +
-              "' is 0 and dimensions are not defined for all " + key));
-
-      triton::common::TritonJson::Value check_dims(
-          model_state_->ModelConfig(),
-          triton::common::TritonJson::ValueType::OBJECT);
-      for (size_t i = 0; i < io_size; ++i) {
-        triton::common::TritonJson::Value current_io_object(
-            model_state_->ModelConfig(),
-            triton::common::TritonJson::ValueType::OBJECT);
-        ios.IndexAsObject(i, &current_io_object);
-
-        bool found_dims = current_io_object.Find("dims", &check_dims);
-        RETURN_ERROR_IF_TRUE(
-            !found_dims, TRITONSERVER_ERROR_INVALID_ARG,
-            std::string(
-                "Unable to autofill for '" + model_state_->Name() +
-                "': the rank of model tensor '" + io->name_ +
-                "' is 0 and dimensions are not defined for all " + key));
-      }
-    } else if (io->shape_->rank_ > 0 && !found_ios) {
-      // The model signature supports batching then the first
-      // dimension is -1 and should not appear in the model
-      // configuration 'dims' that we are creating.
-      for (size_t i = (model_support_batching_ ? 1 : 0); i < io->shape_->rank_;
-           ++i) {
-        RETURN_IF_ERROR(dims.AppendInt(io->shape_->dims_[i]));
-      }
-
-      // If io dims are empty then must use a reshape for the
-      // io, since 'dims' is not allowed to be empty.
-      if (dims.ArraySize() == 0) {
-        RETURN_IF_ERROR(dims.AppendInt(1));
-        triton::common::TritonJson::Value reshape(
-            model_state_->ModelConfig(),
-            triton::common::TritonJson::ValueType::OBJECT);
-        triton::common::TritonJson::Value reshape_dims(
-            model_state_->ModelConfig(),
-            triton::common::TritonJson::ValueType::ARRAY);
-        RETURN_IF_ERROR(reshape.Add("shape", std::move(reshape_dims)));
-        RETURN_IF_ERROR(auto_complete_io.Add("reshape", std::move(reshape)));
-      }
-      RETURN_IF_ERROR(auto_complete_io.Add("dims", std::move(dims)));
-      RETURN_IF_ERROR(auto_complete_ios.Append(std::move(auto_complete_io)));
-
-      model_state_->ModelConfig().Add(key, std::move(auto_complete_ios));
-    } else if (io->shape_->rank_ > 0 && found_ios) {
-      // The number of elements in dims should match 'rank - 1'
-      // when the model supports batching; otherwise, number of
-      // elements in dims should match 'rank'. This does not
-      // try to overwrite the user provided configuration, throws
-      // error instead.
-      // However, ragged batching is an exception to this rule. A
-      // tensor allowing ragged batch should not match with
-      // 'rank - 1'.
-      size_t io_size = ios.ArraySize();
-      for (size_t i = 0; i < io_size; ++i) {
-        triton::common::TritonJson::Value current_io_object(
-            model_state_->ModelConfig(),
-            triton::common::TritonJson::ValueType::OBJECT);
-        ios.IndexAsObject(i, &current_io_object);
-
-        json_buffer.Clear();
-        current_io_object.PrettyWriteValue(&json_buffer);
-        LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("CURRENT_IO_OBJECT: \n") + json_buffer.Contents()).c_str());
-
-        triton::common::TritonJson::Value current_dims(
-            model_state_->ModelConfig(),
-            triton::common::TritonJson::ValueType::ARRAY);
-        current_io_object.Find("dims", &current_dims);
-
-        json_buffer.Clear();
-        current_dims.PrettyWriteValue(&json_buffer);
-        LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("CURRENT_DIMS: \n") + json_buffer.Contents()).c_str());
-
-        size_t dims_size = dims.ArraySize();
-        size_t non_negative_dim_values = 0;
-        int64_t tmp;
-        for (size_t j = 0; j < dims_size; ++j) {
-          current_dims.IndexAsInt(j, &tmp);
-          if (tmp != -1) {
-            ++non_negative_dim_values;
-          }
-        }
-        size_t adjusted_dims_size = (model_support_batching_ ? dims_size -1 : dims_size);
-        LOG_MESSAGE(TRITONSERVER_LOG_ERROR, (std::string("ADJUSTED_DIMS_SIZE: \n") + std::to_string(adjusted_dims_size)).c_str() );
-
-        if (model_support_batching_) {
-          RETURN_ERROR_IF_TRUE(
-              current_dims.ArraySize() != (io->shape_->rank_ - 1),
-              TRITONSERVER_ERROR_INVALID_ARG,
-              std::string(
-                  "Number of dimensions (" + std::to_string(dims.ArraySize()) +
-                  ") given for '" + model_state_->Name() +
-                  "' in configuration does not match the rank (" +
-                  std::to_string(io->shape_->rank_ - 1) +
-                  ")of the loaded model."));
-        } else {
-          RETURN_ERROR_IF_TRUE(
-              current_dims.ArraySize() != io->shape_->rank_,
-              TRITONSERVER_ERROR_INVALID_ARG,
-              std::string(
-                  "Number of dimensions (" + std::to_string(dims.ArraySize()) +
-                  ") given for '" + model_state_->Name() +
-                  "' in configuration does not match the rank (" +
-                  std::to_string(io->shape_->rank_) +
-                  ") of the loaded model."));
-        }
-      }
-    } else {
-      RETURN_ERROR_IF_TRUE(
-          io->shape_->rank_ == 0, TRITONSERVER_ERROR_INVALID_ARG,
-          std::string(
-              "Unable to autofill for '" + model_state_->Name() +
-              "': the rank of model tensor '" + io->name_ +
-              "' is 0 which is not supported"));
-    }
-  }
-
   return nullptr;  // success
 }
 

--- a/src/tensorflow.cc
+++ b/src/tensorflow.cc
@@ -1348,7 +1348,7 @@ AutoCompleteHelper::FillMissingValues(
       model_state_->ModelConfig(),
       triton::common::TritonJson::ValueType::OBJECT);
 
-  bool is_empty_io = io_config.Empty();
+  bool is_empty_io = io_config.IsEmpty();
   if (!is_empty_io && !io_config.Find("name", &tmp)) {
     return TRITONSERVER_ErrorNew(
           TRITONSERVER_ERROR_INVALID_ARG,

--- a/src/tensorflow.cc
+++ b/src/tensorflow.cc
@@ -1373,7 +1373,7 @@ AutoCompleteHelper::FillMissingValues(
   bool should_auto_complete_data_type =
       !found_config_data_type || DataTypeIsInvalid(data_type_str);
   if (should_auto_complete_data_type) {
-    io_config.SetString("data_type", ConvertToModelConfigString(io->data_type_));
+    io_config.SetStringObject("data_type", ConvertToModelConfigString(io->data_type_));
   }
 
   bool found_dims = io_config.Find("dims", &tmp);
@@ -1630,54 +1630,6 @@ ModelState::AutoCompleteConfig()
   return nullptr;  // success
 }
 
-/*
-  TODO: CHECK FOR THE FOLLOWING:
-----------------------------
-  RETURN_ERROR_IF_TRUE(
-      ios.ArraySize() > reference_list_copy.size(),
-      TRITONSERVER_ERROR_INVALID_ARG,
-      (std::string("Config file specifies too many inputs, ") +
-       std::to_string(ios.ArraySize()) + std::string(", while loaded model '") +
-       model_state_->Name() + std::string("' specifies ") +
-       std::to_string(reference_list_copy.size())));
-
-------------------------------
-  
-  // Elements in dims should match 'rank'. However, ragged batching is an
-  // exception to this rule. A tensor allowing ragged batch should not match
-  // with 'rank - 1'.
-  if (!using_ragged_batching_) {
-    triton::common::TritonJson::Value current_dims(
-        model_state_->ModelConfig(),
-        triton::common::TritonJson::ValueType::ARRAY);
-    io_config.Find("dims", &current_dims);
-
-    if (model_support_batching_) {
-      RETURN_ERROR_IF_TRUE(
-          current_dims.ArraySize() != (io->shape_->rank_ - 1),
-          TRITONSERVER_ERROR_INVALID_ARG,
-          std::string(
-              "Number of dimensions (" +
-              std::to_string(current_dims.ArraySize()) + ") given for tensor " +
-              io->name_ + " for model '" + model_state_->Name() +
-              "' in configuration does not match the rank (" +
-              std::to_string(io->shape_->rank_ - 1) +
-              ") of the loaded model."));
-    } else {
-      RETURN_ERROR_IF_TRUE(
-          current_dims.ArraySize() != io->shape_->rank_,
-          TRITONSERVER_ERROR_INVALID_ARG,
-          std::string(
-              "Number of dimensions (" +
-              std::to_string(current_dims.ArraySize()) + ") given for tensor " +
-              io->name_ + " for model '" + model_state_->Name() +
-              "' in configuration does not match the rank (" +
-              std::to_string(io->shape_->rank_) + ") of the loaded model."));
-    }
-  }
-
-
-*/
 TRITONSERVER_Error*
 ModelState::ValidateModelConfig()
 {

--- a/src/tensorflow_utils.cc
+++ b/src/tensorflow_utils.cc
@@ -118,6 +118,19 @@ FindIOByName(const TRITONTF_IOList* ios, const std::string& name)
   return nullptr;
 }
 
+const TRITONTF_IO*
+FindIOByName(
+    const std::vector<const TRITONTF_IOList*> ios, std::string& name)
+{
+  for (const auto itr : ios) {
+    if (itr->io_->name_ == name) {
+      return itr->io_;
+    }
+  }
+
+  return nullptr;
+}
+
 std::string
 ShapeToString(const TRITONTF_Shape* shape, const size_t start_idx)
 {

--- a/src/tensorflow_utils.cc
+++ b/src/tensorflow_utils.cc
@@ -145,6 +145,13 @@ CompareDataType(TRITONTF_DataType model_dtype, const std::string& dtype)
   return model_dtype == cdtype;
 }
 
+bool
+DataTypeIsInvalid(const std::string& dtype)
+{
+  auto cdtype = ConvertDataType(dtype);
+  return cdtype == TRITONTF_TYPE_INVALID;
+}
+
 TRITONSERVER_DataType
 ConvertDataType(TRITONTF_DataType dtype)
 {

--- a/src/tensorflow_utils.h
+++ b/src/tensorflow_utils.h
@@ -49,6 +49,10 @@ TRITONSERVER_Error* CompareDims(
 const TRITONTF_IO* FindIOByName(
     const TRITONTF_IOList* ios, const std::string& name);
 
+/// \return a named input/output tensor. Return nullptr if not found.
+const TRITONTF_IO* FindIOByName(
+    const std::vector<const TRITONTF_IOList*> ios, std::string& name);
+
 // Convert a vector representing a shape to string representation.
 /// \param dims The vector of dimensions to be converted.
 /// \return String representation of the vector in pattern

--- a/src/tensorflow_utils.h
+++ b/src/tensorflow_utils.h
@@ -60,6 +60,9 @@ std::string ShapeToString(
 /// data-type.
 bool CompareDataType(TRITONTF_DataType model_dtype, const std::string& dtype);
 
+/// \return true if a model configuration data-type is invalid
+bool DataTypeIsInvalid(const std::string& dtype);
+
 /// \return the TRITONSERVER data-type that corresponds to a
 /// TRITONTF data-type.
 TRITONSERVER_DataType ConvertDataType(TRITONTF_DataType dtype);


### PR DESCRIPTION
This PR enhances the tensorflow autocomplete feature to use the user's config file as hints rather than discarding it. these changes assert new behavior as defined by the refactored tests in L0_model_config.

Before:
- Autocomplete discarded the user's config file and completed using the loaded model 
- Allowed the user to provide bad config parameters in their config.pbtxt and autocomplete would overwrite them completely

After:
- Autocomplete uses the user's config file as hints and checks them against the loaded model.
  - If there is a bad configuration in the user's file, we will now suggest to omit the part which threw the error.
- Tensorflow autocomplete now checks the following for inputs/outputs:
  - name is present
  - data_type is valid
  - dims is valid
  - reshape is valid
  - ~~validates all inputs are defined correctly~~
  - If inputs are omitted, autocomplete attempts to fill them in before failing
  - ~~validates all outputs are defined correctly~~
  - If outputs are omitted in config.pbtxt then autocomplete ignores them
  - If outputs are empty in config.pbtxt then autocomplete attempts to populate them