### PR TITLE
Auto complete now uses default-max-batch-size

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,21 @@ GPU memory.
 Select the version of the TensorFlow library to be used, available
 versions are 1 and 2. Default version is 1.
 
+##### --backend-config=tensorflow,default-max-batch-size=\<int\>
+
+The default value to use for max_batch_size during [auto-completing model configuration](https://github.com/triton-inference-server/server/blob/main/docs/model_configuration.md#auto-generated-model-configuration)
+when batching support is detected in the model. If the `--strict-model-config=false`
+command-line option is used, the tensorflow backend will set the
+max_batch_size of the model to this default value under the following 
+conditions:
+
+1. Autocomplete has determined the model is capable of batching requests. 
+2. max_batch_size is 0 in the model configuration or max_batch_size 
+   is omitted from the model configuration.
+
+If max_batch_size > 1 and no [scheduler](https://github.com/triton-inference-server/server/blob/main/docs/model_configuration.md#scheduling-and-batching) 
+is provided, the dynamic batch scheduler will be enabled.
+
 ## Build the TensorFlow Backend
 
 Use a recent cmake to build. First install the required dependencies.

--- a/src/tensorflow.cc
+++ b/src/tensorflow.cc
@@ -1372,7 +1372,7 @@ AutoCompleteHelper::FixIOConfig(
     // If the model supports batching and the max_batch_size
     // is 0, then batching is turned off and the IO dimensions
     // must be explicit.
-    size_t start_index =
+    const size_t start_index =
         (model_support_batching_ && model_state_->MaxBatchSize() > 0) ? 1 : 0;
     for (size_t i = start_index; i < io->shape_->rank_; ++i) {
       RETURN_IF_ERROR(dims.AppendInt(io->shape_->dims_[i]));


### PR DESCRIPTION
Tensorflow backend now uses the default-max-batch-size which is passed to it if no other batch sizes are found. If the final max-batch-size is greater than 1 then the backend turns on dynamic batching if no other schedulers are found.