### PR TITLE
Updated Fix Batching Support for Autocomplete

### DIFF
--- a/src/tensorflow.cc
+++ b/src/tensorflow.cc
@@ -1241,7 +1241,6 @@ AutoCompleteHelper::FixBatchingSupport()
     // (i.e. non-batch model with variable size tensors). As 'max_batch_size == 0'
     // from existing config is also ambiguous, it can be either unspecified or
     // no-batch, autofill will check specified input/output (if any) for hint.
-    config_batch_hint = false;
     triton::common::TritonJson::Value config_inputs(
         model_state_->ModelConfig(),
         triton::common::TritonJson::ValueType::ARRAY);

--- a/src/tensorflow.cc
+++ b/src/tensorflow.cc
@@ -1160,10 +1160,7 @@ class AutoCompleteHelper {
  private:
   TRITONSERVER_Error* FixBatchingSupport_();
   TRITONSERVER_Error* FixBatchingSupport();
-<<<<<<< HEAD
   TRITONSERVER_Error* FixConfigInputs(const TRITONTF_IOList* reference_list);
-
-<<<<<<< HEAD
   TRITONSERVER_Error* FixConfigOutputs(const TRITONTF_IOList* reference_list);
 
   void RemoveByName(
@@ -1173,27 +1170,11 @@ class AutoCompleteHelper {
 
   TRITONSERVER_Error* FillMissingValues(
       const TRITONTF_IO* io, triton::common::TritonJson::Value& config);
-=======
-  TRITONSERVER_Error* FixIOConfigInputs(
-    const TRITONTF_IOList* reference_list);
-=======
-  TRITONSERVER_Error* FixIOConfigInputs(const TRITONTF_IOList* reference_list);
-
-  TRITONSERVER_Error* FixIOConfigOutputs(const TRITONTF_IOList* reference_list);
->>>>>>> tf autocomplete working; debug messages
 
   void RemoveFromListByName(
       const char* name, std::vector<const TRITONTF_IOList*>& list);
 
   std::vector<const TRITONTF_IOList*> CopyList(const TRITONTF_IOList* list);
-
-  TRITONSERVER_Error* FillMissingValues(
-<<<<<<< HEAD
-    TRITONTF_IO* io, triton::common::TritonJson::Value &config);
->>>>>>> messy debug code
-=======
-      TRITONTF_IO* io, triton::common::TritonJson::Value& config);
->>>>>>> tf autocomplete working; debug messages
 
   ModelState* model_state_;
   std::unique_ptr<TRITONTF_Model, decltype(&TRITONTF_ModelDelete)>
@@ -1212,19 +1193,11 @@ AutoCompleteHelper::Fix()
 
   // Inputs
   const TRITONTF_IOList* inputs = TRITONTF_ModelInputs(tritontf_model_.get());
-<<<<<<< HEAD
   RETURN_IF_ERROR(FixConfigInputs(inputs));
 
   // Outputs
   const TRITONTF_IOList* outputs = TRITONTF_ModelOutputs(tritontf_model_.get());
   RETURN_IF_ERROR(FixConfigOutputs(outputs));
-=======
-  RETURN_IF_ERROR(FixIOConfigInputs(inputs));
-
-  // Outputs
-  const TRITONTF_IOList* outputs = TRITONTF_ModelOutputs(tritontf_model_.get());
-  RETURN_IF_ERROR(FixIOConfigOutputs(outputs));
->>>>>>> messy debug code
 
   return nullptr;  // success
 }
@@ -1529,349 +1502,6 @@ AutoCompleteHelper::FixBatchingSupport()
   return nullptr;  // success
 }
 
-TRITONTF_IO*
-FindModelIOByName(
-    const char* name, const std::vector<const TRITONTF_IOList*> list)
-{
-  if (name == nullptr) {
-    return nullptr;
-  }
-
-  for (const auto item : list) {
-    TRITONTF_IO* io = item->io_;
-    if (!strcmp(name, io->name_)) {
-      return io;
-    }
-  }
-
-  return nullptr;
-}
-
-TRITONTF_IO*
-FindModelIOByName(const char* name, const TRITONTF_IOList* list)
-{
-  if (name == nullptr) {
-    return nullptr;
-  }
-
-  while (list) {
-    TRITONTF_IO* io = list->io_;
-    if (!strcmp(name, io->name_)) {
-      return io;
-    }
-    list = list->next_;
-  }
-
-  return nullptr;
-}
-
-
-TRITONSERVER_Error*
-AutoCompleteHelper::FillMissingValues(
-    TRITONTF_IO* io, triton::common::TritonJson::Value& config)
-{
-  triton::common::TritonJson::Value tmp(
-      model_state_->ModelConfig(),
-      triton::common::TritonJson::ValueType::OBJECT);
-
-  bool found_name = config.Find("name", &tmp);
-  if (!found_name) {
-    triton::common::TritonJson::Value name;
-    RETURN_IF_ERROR(config.AddString("name", io->name_));
-  }
-
-  bool found_config_data_type = config.Find("data_type", &tmp);
-  std::string data_type_str;
-  tmp.AsString(&data_type_str);
-  bool should_auto_complete_data_type =
-      !found_config_data_type || DataTypeIsInvalid(data_type_str);
-  if (should_auto_complete_data_type) {
-    config.SetString("data_type", ConvertToModelConfigString(io->data_type_));
-  }
-
-  bool found_dims = config.Find("dims", &tmp);
-  bool should_auto_complete_dims = !found_dims || (tmp.ArraySize() == 0);
-  if (should_auto_complete_dims) {
-    RETURN_ERROR_IF_TRUE(
-        io->shape_->rank_ == 0, TRITONSERVER_ERROR_INVALID_ARG,
-        std::string(
-            "Unable to autofill for '" + model_state_->Name() +
-            "': the rank of model tensor '" + io->name_ +
-            "' is 0 and dimensions are not defined"));
-    // The model signature supports batching then the first
-    // dimension is -1 and should not appear in the model
-    // configuration 'dims' that we are creating.
-    triton::common::TritonJson::Value dims(
-        model_state_->ModelConfig(),
-        triton::common::TritonJson::ValueType::ARRAY);
-
-    for (size_t i = (model_support_batching_ ? 1 : 0); i < io->shape_->rank_;
-         ++i) {
-      RETURN_IF_ERROR(dims.AppendInt(io->shape_->dims_[i]));
-    }
-    if (dims.ArraySize() == 0) {
-      RETURN_IF_ERROR(dims.AppendInt(1));
-      triton::common::TritonJson::Value reshape(
-          model_state_->ModelConfig(),
-          triton::common::TritonJson::ValueType::OBJECT);
-      triton::common::TritonJson::Value reshape_dims(
-          model_state_->ModelConfig(),
-          triton::common::TritonJson::ValueType::ARRAY);
-      RETURN_IF_ERROR(reshape.Add("shape", std::move(reshape_dims)));
-      RETURN_IF_ERROR(config.Add("reshape", std::move(reshape)));
-    }
-
-    if (found_dims) {
-      RETURN_IF_ERROR(config.Remove("dims"));
-    }
-    RETURN_IF_ERROR(config.Add("dims", std::move(dims)));
-  }
-
-  // There may need to be a reshape if batching is enabled. Solving the 
-  // issue of the savedmodel having ambiguous shape and configuration 
-  // defines dimensions which can be batched.
-  if (model_state_->MaxBatchSize() > 0) {
-    triton::common::TritonJson::Value dims;
-    triton::common::TritonJson::Value reshape(
-          model_state_->ModelConfig(),
-          triton::common::TritonJson::ValueType::OBJECT);
-    config.Find("dims", &dims);
-    
-    int64_t first_dim;
-    RETURN_IF_ERROR(dims.IndexAsInt(0, &first_dim));
-    
-    bool found_reshape = config.Find("reshape", &reshape);
-    bool add_empty_reshape_to_config = (dims.ArraySize() == 1) && (first_dim == 1) && !found_reshape;
-    if (add_empty_reshape_to_config) {
-      triton::common::TritonJson::Value reshape_dims(model_state_->ModelConfig(), triton::common::TritonJson::ValueType::ARRAY);
-      RETURN_IF_ERROR(reshape.Add("shape", std::move(reshape_dims)));
-      RETURN_IF_ERROR(config.Add("reshape", std::move(reshape)));
-    }
-  }
-
-
-  // Elements in dims should match 'rank'. However, ragged batching is an
-  // exception to this rule. A tensor allowing ragged batch should not match
-  // with 'rank - 1'.
-  if (!using_ragged_batching_) {
-    triton::common::TritonJson::Value current_dims;
-    triton::common::TritonJson::Value reshape;
-    if (config.Find("reshape", &reshape)) {
-      reshape.MemberAsArray("shape", &current_dims);
-    } else {
-      config.MemberAsArray("dims", &current_dims);
-    }
-
-    if (io->shape_->rank_ > 0) {
-      if (model_support_batching_) {
-        RETURN_ERROR_IF_TRUE(
-            current_dims.ArraySize() != (io->shape_->rank_ - 1),
-            TRITONSERVER_ERROR_INVALID_ARG,
-            std::string(
-                "Number of dimensions (" +
-                std::to_string(current_dims.ArraySize()) + ") given for tensor " +
-                io->name_ + " for model '" + model_state_->Name() +
-                "' in configuration does not match the rank (" +
-                std::to_string(io->shape_->rank_ - 1) +
-                ") of the loaded model."));
-      } else {
-        // FIXME: This incorrectly triggers when rank equals 0
-        RETURN_ERROR_IF_TRUE(
-            current_dims.ArraySize() != io->shape_->rank_,
-            TRITONSERVER_ERROR_INVALID_ARG,
-            std::string(
-                "Number of dimensions (" +
-                std::to_string(current_dims.ArraySize()) + ") given for tensor " +
-                io->name_ + " for model '" + model_state_->Name() +
-                "' in configuration does not match the rank (" +
-                std::to_string(io->shape_->rank_) + ") of the loaded model."));
-      }
-    }
-  }
-
-  return nullptr;  // Success
-}
-
-void
-AutoCompleteHelper::RemoveFromListByName(
-    const char* name, std::vector<const TRITONTF_IOList*>& list)
-{
-  for (size_t i = 0; i < list.size(); ++i) {
-    const TRITONTF_IOList* current = list.at(i);
-    if (!strcmp(name, current->io_->name_)) {
-      list.erase(list.begin() + i);
-      return;
-    }
-  }
-}
-
-std::vector<const TRITONTF_IOList*>
-AutoCompleteHelper::CopyList(const TRITONTF_IOList* list)
-{
-  std::vector<const TRITONTF_IOList*> copy;
-  if (list == nullptr) {
-    return copy;
-  }
-
-  while (list != nullptr) {
-    copy.push_back(list);
-    list = list->next_;
-  }
-
-  return copy;
-}
-
-TRITONSERVER_Error*
-AutoCompleteHelper::FixIOConfigInputs(const TRITONTF_IOList* reference_list)
-{
-  triton::common::TritonJson::WriteBuffer json_buffer;
-  model_state_->ModelConfig().PrettyWrite(&json_buffer);
-  LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("MODEL CONFIG BEFORE FIX:\n")
-      + json_buffer.Contents()).c_str());
-
-  triton::common::TritonJson::Value ios;
-  model_state_->ModelConfig().Find("input", &ios);
-
-  // Input names must all be defined and match the user provided config.
-  // - If there is an input from the model which is not in config.pbtxt
-  //   then we try to autocomplete it.
-  // - If there is an input in the config.pbtxt
-  //   which is not in the model then we throw an error.
-  std::vector<const TRITONTF_IOList*> reference_list_copy =
-      CopyList(reference_list);
-  RETURN_ERROR_IF_TRUE(
-      ios.ArraySize() > reference_list_copy.size(),
-      TRITONSERVER_ERROR_INVALID_ARG,
-      (std::string("Config file specifies too many inputs, ") +
-       std::to_string(ios.ArraySize()) + std::string(", while loaded model '") +
-       model_state_->Name() + std::string("' specifies ") +
-       std::to_string(reference_list_copy.size())));
-
-  triton::common::TritonJson::Value current_io(
-      model_state_->ModelConfig(),
-      triton::common::TritonJson::ValueType::OBJECT);
-  for (size_t i = 0; i < ios.ArraySize(); ++i) {
-    ios.IndexAsObject(i, &current_io);
-
-    triton::common::TritonJson::Value current_name(
-        model_state_->ModelConfig(),
-        triton::common::TritonJson::ValueType::OBJECT);
-    std::string config_name;
-    RETURN_IF_ERROR(current_io.MemberAsString("name", &config_name));
-
-    TRITONTF_IO* io =
-        FindModelIOByName(config_name.c_str(), reference_list_copy);
-    RETURN_ERROR_IF_TRUE(
-        io == nullptr, TRITONSERVER_ERROR_INVALID_ARG,
-        (std::string("Config file provided input name '") + config_name +
-         std::string("' but none found in loaded model '") +
-         model_state_->Name() + std::string("'.")));
-
-    RETURN_IF_ERROR(FillMissingValues(io, current_io));
-
-    RemoveFromListByName(io->name_, reference_list_copy);
-  }
-
-  for (size_t i = 0; i < reference_list_copy.size(); ++i) {
-    const TRITONTF_IOList* current = reference_list_copy.at(i);
-    TRITONTF_IO* io = current->io_;
-
-    triton::common::TritonJson::Value blank_value(
-        model_state_->ModelConfig(),
-        triton::common::TritonJson::ValueType::OBJECT);
-
-    RETURN_IF_ERROR(FillMissingValues(io, blank_value));
-
-    ios.Append(std::move(blank_value));
-  }
-  reference_list_copy.clear();
-
-  return nullptr;  // success
-}
-
-TRITONSERVER_Error*
-AutoCompleteHelper::FixIOConfigOutputs(const TRITONTF_IOList* reference_list)
-{
-  triton::common::TritonJson::Value ios;
-  bool found_ios = model_state_->ModelConfig().Find("output", &ios);
-
-  // If output is empty or undefined then autocomplete this otherwise
-  // only check the defined outputs
-  bool should_auto_complete_output = (!found_ios || ios.ArraySize() == 0);
-  if (should_auto_complete_output) {
-    triton::common::TritonJson::Value auto_complete_ios(
-        model_state_->ModelConfig(),
-        triton::common::TritonJson::ValueType::ARRAY);
-    for (const TRITONTF_IOList* itr = reference_list; itr != nullptr;
-         itr = itr->next_) {
-      TRITONTF_IO* io = itr->io_;
-
-      triton::common::TritonJson::Value auto_complete_io(
-          model_state_->ModelConfig(),
-          triton::common::TritonJson::ValueType::OBJECT);
-      RETURN_IF_ERROR(auto_complete_io.AddString("name", io->name_));
-      RETURN_IF_ERROR(auto_complete_io.AddString(
-          "data_type", ConvertToModelConfigString(io->data_type_)));
-      triton::common::TritonJson::Value dims(
-          model_state_->ModelConfig(),
-          triton::common::TritonJson::ValueType::ARRAY);
-      RETURN_ERROR_IF_TRUE(
-          io->shape_->rank_ == 0, TRITONSERVER_ERROR_INVALID_ARG,
-          std::string(
-              "Unable to autofill for '" + model_state_->Name() +
-              "': the rank of model tensor '" + io->name_ +
-              "' is 0 which is not supported"));
-      // The model signature supports batching then the first
-      // dimension is -1 and should not appear in the model
-      // configuration 'dims' that we are creating.
-      for (size_t i = (model_support_batching_ ? 1 : 0); i < io->shape_->rank_;
-           ++i) {
-        RETURN_IF_ERROR(dims.AppendInt(io->shape_->dims_[i]));
-      }
-
-      // If io dims are empty then must use a reshape for the
-      // io, since 'dims' is not allowed to be empty.
-      if (dims.ArraySize() == 0) {
-        RETURN_IF_ERROR(dims.AppendInt(1));
-        triton::common::TritonJson::Value reshape(
-            model_state_->ModelConfig(),
-            triton::common::TritonJson::ValueType::OBJECT);
-        triton::common::TritonJson::Value reshape_dims(
-            model_state_->ModelConfig(),
-            triton::common::TritonJson::ValueType::ARRAY);
-        RETURN_IF_ERROR(reshape.Add("shape", std::move(reshape_dims)));
-        RETURN_IF_ERROR(auto_complete_io.Add("reshape", std::move(reshape)));
-      }
-      RETURN_IF_ERROR(auto_complete_io.Add("dims", std::move(dims)));
-      RETURN_IF_ERROR(auto_complete_ios.Append(std::move(auto_complete_io)));
-    }
-    if (found_ios) {
-      ios.Swap(auto_complete_ios);
-    } else {
-      model_state_->ModelConfig().Add("output", std::move(auto_complete_ios));
-    }
-  } else {
-    // don't need to check what was processed at the end so no need to copy
-    triton::common::TritonJson::Value current_io(
-        model_state_->ModelConfig(),
-        triton::common::TritonJson::ValueType::OBJECT);
-    for (size_t i = 0; i < ios.ArraySize(); ++i) {
-      ios.IndexAsObject(i, &current_io);
-
-      std::string output_name;
-      RETURN_IF_ERROR(current_io.MemberAsString("name", &output_name));
-
-      TRITONTF_IO* io = FindModelIOByName(output_name.c_str(), reference_list);
-<<<<<<< HEAD
-
-      // may want to rethink the swap in this
-      FillMissingValues(io, current_io);
-    }
-  }
-  return nullptr;  // success
-}
-
-
 TRITONSERVER_Error*
 AutoCompleteHelper::FillMissingValues(
     const TRITONTF_IO* io, triton::common::TritonJson::Value& io_config)
@@ -1969,18 +1599,13 @@ AutoCompleteHelper::CopyList(const TRITONTF_IOList* src, std::vector<const TRITO
 TRITONSERVER_Error*
 AutoCompleteHelper::FixConfigInputs(const TRITONTF_IOList* reference_list)
 {
-<<<<<<< HEAD
-=======
-
   //nocheckin
   triton::common::TritonJson::WriteBuffer json_buffer;
 
   // Replace I/O even if inputs / outputs are specified in config.
->>>>>>> messy debug code
   triton::common::TritonJson::Value ios;
   model_state_->ModelConfig().Find("input", &ios);
 
-<<<<<<< HEAD
   // Iterate through the model config inputs and keep track of
   // the ones which we found in the model. Any inputs left in the 
   // model list, we will attempt to autocomplete after. In the 
@@ -1990,13 +1615,6 @@ AutoCompleteHelper::FixConfigInputs(const TRITONTF_IOList* reference_list)
   CopyList(reference_list, reference_list_copy);
 
   triton::common::TritonJson::Value current_io(
-=======
-  json_buffer.Clear();
-  ios.PrettyWriteValue(&json_buffer);
-  LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("IOS: \n") + json_buffer.Contents()).c_str());
-
-  triton::common::TritonJson::Value auto_complete_ios(
->>>>>>> messy debug code
       model_state_->ModelConfig(),
       triton::common::TritonJson::ValueType::OBJECT);
   for (size_t i = 0; i < ios.ArraySize(); ++i) {
@@ -2108,88 +1726,14 @@ AutoCompleteHelper::FixConfigOutputs(const TRITONTF_IOList* reference_list)
     for (size_t i = 0; i < ios.ArraySize(); ++i) {
       ios.IndexAsObject(i, &current_io);
 
-<<<<<<< HEAD
       std::string output_name;
       RETURN_IF_ERROR(current_io.MemberAsString("name", &output_name));
 
       const TRITONTF_IO* io = FindIOByName(reference_list, output_name);
       if (io == nullptr) {
         continue;
-=======
-      model_state_->ModelConfig().Add(key, std::move(auto_complete_ios));
-    } else if (io->shape_->rank_ > 0 && found_ios) {
-      // The number of elements in dims should match 'rank - 1'
-      // when the model supports batching; otherwise, number of
-      // elements in dims should match 'rank'. This does not
-      // try to overwrite the user provided configuration, throws
-      // error instead.
-      // However, ragged batching is an exception to this rule. A
-      // tensor allowing ragged batch should not match with
-      // 'rank - 1'.
-      size_t io_size = ios.ArraySize();
-      for (size_t i = 0; i < io_size; ++i) {
-        triton::common::TritonJson::Value current_io_object(
-            model_state_->ModelConfig(),
-            triton::common::TritonJson::ValueType::OBJECT);
-        ios.IndexAsObject(i, &current_io_object);
-
-        json_buffer.Clear();
-        current_io_object.PrettyWriteValue(&json_buffer);
-        LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("CURRENT_IO_OBJECT: \n") + json_buffer.Contents()).c_str());
-
-        triton::common::TritonJson::Value current_dims(
-            model_state_->ModelConfig(),
-            triton::common::TritonJson::ValueType::ARRAY);
-        current_io_object.Find("dims", &current_dims);
-
-        json_buffer.Clear();
-        current_dims.PrettyWriteValue(&json_buffer);
-        LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("CURRENT_DIMS: \n") + json_buffer.Contents()).c_str());
-
-        size_t dims_size = dims.ArraySize();
-        size_t non_negative_dim_values = 0;
-        int64_t tmp;
-        for (size_t j = 0; j < dims_size; ++j) {
-          current_dims.IndexAsInt(j, &tmp);
-          if (tmp != -1) {
-            ++non_negative_dim_values;
-          }
-        }
-        size_t adjusted_dims_size = (model_support_batching_ ? dims_size -1 : dims_size);
-        LOG_MESSAGE(TRITONSERVER_LOG_ERROR, (std::string("ADJUSTED_DIMS_SIZE: \n") + std::to_string(adjusted_dims_size)).c_str() );
-
-        if (model_support_batching_) {
-          RETURN_ERROR_IF_TRUE(
-              current_dims.ArraySize() != (io->shape_->rank_ - 1),
-              TRITONSERVER_ERROR_INVALID_ARG,
-              std::string(
-                  "Number of dimensions (" + std::to_string(dims.ArraySize()) +
-                  ") given for '" + model_state_->Name() +
-                  "' in configuration does not match the rank (" +
-                  std::to_string(io->shape_->rank_ - 1) +
-                  ")of the loaded model."));
-        } else {
-          RETURN_ERROR_IF_TRUE(
-              current_dims.ArraySize() != io->shape_->rank_,
-              TRITONSERVER_ERROR_INVALID_ARG,
-              std::string(
-                  "Number of dimensions (" + std::to_string(dims.ArraySize()) +
-                  ") given for '" + model_state_->Name() +
-                  "' in configuration does not match the rank (" +
-                  std::to_string(io->shape_->rank_) +
-                  ") of the loaded model."));
-        }
->>>>>>> messy debug code
       }
 
-=======
-      RETURN_ERROR_IF_TRUE(
-          io == nullptr, TRITONSERVER_ERROR_INVALID_ARG,
-          (std::string("Config file provided output name '") + output_name +
-           std::string("' but none found in loaded model '") +
-           model_state_->Name() + std::string("'.")));
-
->>>>>>> tf autocomplete working; debug messages
       FillMissingValues(io, current_io);
     }
   }

--- a/src/tensorflow.cc
+++ b/src/tensorflow.cc
@@ -1277,7 +1277,6 @@ AutoCompleteHelper::FixBatchingSupport()
                    itr != nullptr; itr = itr->next_) {
                 TRITONTF_IO* io = itr->io_;
                 if (config_name == io->name_) {
-
                   bool model_io_explicit = io->shape_->rank_ > 0;
                   bool user_config_is_defined = config_dims.ArraySize() > 0;
 
@@ -1287,8 +1286,9 @@ AutoCompleteHelper::FixBatchingSupport()
                       config_dims.IndexAsInt(0, &first_config_dim);
                       if (first_config_dim != -1) {
                         config_batch_hint = false;
-                      }                    
-                    } else if (config_dims.ArraySize()-1 != io->shape_->rank_) {
+                      }
+                    } else if (
+                        config_dims.ArraySize() - 1 != io->shape_->rank_) {
                       // Defer error to validation
                       config_batch_hint = false;
                     }
@@ -1297,12 +1297,13 @@ AutoCompleteHelper::FixBatchingSupport()
                     config_dims.IndexAsInt(0, &first_config_dim);
                     if (first_config_dim != -1) {
                       config_batch_hint = false;
-                    }                                        
-                  } else { // (!model_io_explicit && !user_config_is_defined)
+                    }
+                  } else if (!model_io_explicit && !user_config_is_defined) {
                     // Defer error to validation
                     config_batch_hint = false;
-                  }
-                  break; // TRITONTF_IOList* itr
+                  }  // else (model_io_explicit && !user_config_is_defined)
+
+                  break;  // TRITONTF_IOList* itr
                 }
               }
             }

--- a/src/tensorflow.cc
+++ b/src/tensorflow.cc
@@ -1161,6 +1161,7 @@ class AutoCompleteHelper {
   TRITONSERVER_Error* FixBatchingSupport();
   TRITONSERVER_Error* FixConfigInputs(const TRITONTF_IOList* reference_list);
 
+<<<<<<< HEAD
   TRITONSERVER_Error* FixConfigOutputs(const TRITONTF_IOList* reference_list);
 
   void RemoveByName(
@@ -1170,6 +1171,16 @@ class AutoCompleteHelper {
 
   TRITONSERVER_Error* FillMissingValues(
       const TRITONTF_IO* io, triton::common::TritonJson::Value& config);
+=======
+  TRITONSERVER_Error* FixIOConfigInputs(
+    const TRITONTF_IOList* reference_list);
+
+  TRITONSERVER_Error* FixIOConfigOutputs(
+    const TRITONTF_IOList* reference_list);
+
+  TRITONSERVER_Error* FillMissingValues(
+    TRITONTF_IO* io, triton::common::TritonJson::Value &config);
+>>>>>>> messy debug code
 
   ModelState* model_state_;
   std::unique_ptr<TRITONTF_Model, decltype(&TRITONTF_ModelDelete)>
@@ -1187,11 +1198,19 @@ AutoCompleteHelper::Fix()
 
   // Inputs
   const TRITONTF_IOList* inputs = TRITONTF_ModelInputs(tritontf_model_.get());
+<<<<<<< HEAD
   RETURN_IF_ERROR(FixConfigInputs(inputs));
 
   // Outputs
   const TRITONTF_IOList* outputs = TRITONTF_ModelOutputs(tritontf_model_.get());
   RETURN_IF_ERROR(FixConfigOutputs(outputs));
+=======
+  RETURN_IF_ERROR(FixIOConfigInputs(inputs));
+
+  // Outputs
+  const TRITONTF_IOList* outputs = TRITONTF_ModelOutputs(tritontf_model_.get());
+  RETURN_IF_ERROR(FixIOConfigOutputs(outputs));
+>>>>>>> messy debug code
 
   return nullptr;  // success
 }
@@ -1340,6 +1359,348 @@ AutoCompleteHelper::FixBatchingSupport()
   return nullptr;  // success
 }
 
+TRITONTF_IO* FindModelIOByName(const char* name, const std::vector<const TRITONTF_IOList*> list)
+{
+  if (name == nullptr) {
+    return nullptr;
+  }
+
+  for (const auto item : list) {
+    TRITONTF_IO* io = item->io_;
+    if (!strcmp(name, io->name_)) {
+      return io;
+    }
+  } 
+
+  return nullptr;
+}
+
+TRITONTF_IO* FindModelIOByName(const char* name, const TRITONTF_IOList* list)
+{
+  if (name == nullptr) {
+    return nullptr;
+  }
+
+  while(list) {
+    TRITONTF_IO* io = list->io_;
+    if (!strcmp(name, io->name_)) {
+      return io;
+    }
+    list = list->next_;
+  } 
+
+  return nullptr;
+}
+
+
+TRITONSERVER_Error* AutoCompleteHelper::FillMissingValues(
+  TRITONTF_IO* io, triton::common::TritonJson::Value &config)
+{
+  //nocheckin
+  triton::common::TritonJson::WriteBuffer json_buffer;
+
+  json_buffer.Clear();
+  config.PrettyWriteValue(&json_buffer);
+  LOG_MESSAGE(TRITONSERVER_LOG_INFO,
+    (std::string("OLD CONFIG: \n") + json_buffer.Contents()).c_str());
+
+
+  triton::common::TritonJson::Value tmp(
+    model_state_->ModelConfig(),
+    triton::common::TritonJson::ValueType::OBJECT);
+
+  // triton::common::TritonJson::Value auto_complete_io(
+  //   model_state_->ModelConfig(),
+  //   triton::common::TritonJson::ValueType::OBJECT);
+  
+  // check data_type
+  bool found_config_data_type = config.Find("data_type", &tmp);
+  if (!found_config_data_type) {
+    //use the model data type
+    config.AddString("data_type", ConvertToModelConfigString(io->data_type_));
+  }
+
+  // check dims
+  bool found_dims = config.Find("dims", &tmp);
+  if (!found_dims) {
+    RETURN_ERROR_IF_TRUE(
+        io->shape_->rank_ == 0, TRITONSERVER_ERROR_INVALID_ARG,
+        std::string(
+            "Unable to autofill for '" + model_state_->Name() +
+            "': the rank of model tensor '" + io->name_ +
+            "' is 0 and dimensions are not defined");
+    // The model signature supports batching then the first
+    // dimension is -1 and should not appear in the model
+    // configuration 'dims' that we are creating.
+    triton::common::TritonJson::Value dims(
+      model_state_->ModelConfig(),
+      triton::common::TritonJson::ValueType::ARRAY);
+
+    for (size_t i = (model_support_batching_ ? 1 : 0); i < io->shape_->rank_;
+         ++i) {
+      RETURN_IF_ERROR(dims.AppendInt(io->shape_->dims_[i]));
+    }  
+    if (dims.ArraySize() == 0) {
+      RETURN_IF_ERROR(dims.AppendInt(1));
+      triton::common::TritonJson::Value reshape(
+          model_state_->ModelConfig(),
+          triton::common::TritonJson::ValueType::OBJECT);
+      triton::common::TritonJson::Value reshape_dims(
+          model_state_->ModelConfig(),
+          triton::common::TritonJson::ValueType::ARRAY);
+      RETURN_IF_ERROR(reshape.Add("shape", std::move(reshape_dims)));
+      RETURN_IF_ERROR(config.Add("reshape", std::move(reshape)));
+    }
+    RETURN_IF_ERROR(config.Add("dims", std::move(dims)));
+  }
+  // json_buffer.Clear();
+  // auto_complete_io.PrettyWriteValue(&json_buffer);
+  // LOG_MESSAGE(TRITONSERVER_LOG_INFO,
+  //   (std::string("FILLED OUT AUTOCOMPLETE: \n") + json_buffer.Contents()).c_str());
+  
+
+  json_buffer.Clear();
+  config.PrettyWriteValue(&json_buffer);
+  LOG_MESSAGE(TRITONSERVER_LOG_INFO,
+    (std::string("NEW CONFIG: \n") + json_buffer.Contents()).c_str());
+
+  return nullptr;   // Success
+}
+
+void RemoveFromListByName(const char* name, std::vector<const TRITONTF_IOList*>& list)
+{
+  for (size_t i = 0; i < list.size(); ++i) {
+    const TRITONTF_IOList* current = list.at(i);
+    if (!strcmp(name, current->io_->name_)) {
+      std::stringstream ss;
+      ss << current;
+      LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("deleting ptr: ") + ss.str()).c_str());
+      list.erase(list.begin() + i);      
+      return;
+    }
+  }
+}
+
+//deprecated
+/*
+void ClearIOCopy(std::vector<TRITONTF_IOList*>& list) 
+{
+  TRITONTF_IOList* current = list;
+  TRITONTF_IOList* next = current->next_;
+  while(current != nullptr) {
+    std::stringstream ss;
+    ss << current;
+    LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("deleting ptr: ") + ss.str()).c_str());
+    current->io_ = nullptr;
+    current->next_ = nullptr;
+    delete current;
+    
+    current = next;
+    next = current->next_;
+  }
+}
+*/
+std::vector<const TRITONTF_IOList*> CopyList(const TRITONTF_IOList* list)
+{
+  std::vector<const TRITONTF_IOList*> copy;
+  if (list == nullptr) {
+    return copy;
+  }
+
+  while (list != nullptr) {
+    copy.push_back(list);
+    list = list->next_;
+  }
+
+  return copy;
+}
+
+TRITONSERVER_Error* 
+AutoCompleteHelper::FixIOConfigInputs(
+  const TRITONTF_IOList* reference_list) 
+{
+  LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("FIXING INPUTS")).c_str());
+  //nocheckin
+  triton::common::TritonJson::WriteBuffer json_buffer;
+
+  triton::common::TritonJson::Value ios;
+  model_state_->ModelConfig().Find("input", &ios);
+
+  json_buffer.Clear();
+  ios.PrettyWriteValue(&json_buffer);
+  LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("IOS: \n") + json_buffer.Contents()).c_str());
+
+  // Input names must all be defined and match the user provided config.
+  // - If there is an input from the model which is not in config.pbtxt
+  //   then we try to autocomplete it. 
+  // - If there is an input in the config.pbtxt
+  //   which is not in the model then we throw an error.
+  // Iterate through the user provided ios since we expect this to be 
+  std::vector<const TRITONTF_IOList*> reference_list_copy = CopyList(reference_list);
+
+  std::stringstream ss_copy;
+  
+  for(const auto item : reference_list_copy){
+    ss_copy << item << ", ";
+  }
+  LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("copy ptrs: ") + ss_copy.str()).c_str());
+
+  std::stringstream ss_base;
+  const TRITONTF_IOList* debug_ptr = reference_list;
+  while (debug_ptr != nullptr) {
+    ss_base << debug_ptr << ", ";
+    debug_ptr = debug_ptr->next_;
+  }
+  LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("base ptrs: ") + ss_base.str()).c_str());
+
+
+  triton::common::TritonJson::Value current_io(
+      model_state_->ModelConfig(),
+      triton::common::TritonJson::ValueType::OBJECT);
+  for (size_t i = 0; i < ios.ArraySize(); ++i) {
+    ios.IndexAsObject(i, &current_io);
+
+    triton::common::TritonJson::Value current_name(
+      model_state_->ModelConfig(),
+      triton::common::TritonJson::ValueType::OBJECT);
+    std::string config_name;
+    RETURN_IF_ERROR(current_io.MemberAsString("name", &config_name));
+
+    TRITONTF_IO* io = FindModelIOByName(config_name.c_str(), reference_list_copy);
+    if (io == nullptr) {
+      TRITONSERVER_ErrorNew(TRITONSERVER_ERROR_INVALID_ARG, 
+        (std::string("Config file provided input name '") + config_name +
+        std::string("' but none found in loaded model '") +
+        model_state_->Name() + std::string("'.")).c_str());
+    }
+
+    TRITONSERVER_Error* err = FillMissingValues(io, current_io);
+    if (err) {
+      return err;
+    }
+
+    RemoveFromListByName(io->name_, reference_list_copy);
+  }
+  
+  for (size_t i = 0; i < reference_list_copy.size(); ++i) {
+    const TRITONTF_IOList* current = reference_list_copy.at(i);
+    TRITONTF_IO* io = current->io_;
+
+    triton::common::TritonJson::Value blank_value(
+      model_state_->ModelConfig(),
+      triton::common::TritonJson::ValueType::OBJECT);
+
+    TRITONSERVER_Error* err = FillMissingValues(io, blank_value);
+    if (err) {
+      return err;
+    }
+
+    ios.Append(std::move(blank_value));
+  }
+  
+  json_buffer.Clear();
+  ios.PrettyWriteValue(&json_buffer);
+  LOG_MESSAGE(TRITONSERVER_LOG_INFO, 
+    (std::string("FINAL INPUT IOS: \n") + json_buffer.Contents()).c_str());
+
+  // ClearIOCopy(reference_list_copy);
+  reference_list_copy.clear();
+
+  return nullptr;  // success 
+}
+
+TRITONSERVER_Error* 
+AutoCompleteHelper::FixIOConfigOutputs(
+  const TRITONTF_IOList* reference_list) 
+{
+  LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("FIXING OUTPUTS")).c_str());
+  //nocheckin
+  triton::common::TritonJson::WriteBuffer json_buffer;
+
+  triton::common::TritonJson::Value ios;
+  bool found_ios = model_state_->ModelConfig().Find("output", &ios);
+
+  json_buffer.Clear();
+  ios.PrettyWriteValue(&json_buffer);
+  LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("IOS: \n") + json_buffer.Contents()).c_str());
+
+  // If output is empty or undefined then we want to autocomplete this otherwise 
+  // we only want to check the defined outputs
+  bool should_auto_complete_output = (!found_ios || ios.ArraySize() == 0);
+  if (should_auto_complete_output) {
+      triton::common::TritonJson::Value auto_complete_ios(
+      model_state_->ModelConfig(),
+      triton::common::TritonJson::ValueType::ARRAY);
+    for (const TRITONTF_IOList* itr = reference_list; itr != nullptr;
+        itr = itr->next_) {
+      TRITONTF_IO* io = itr->io_;
+
+      triton::common::TritonJson::Value auto_complete_io(
+          model_state_->ModelConfig(),
+          triton::common::TritonJson::ValueType::OBJECT);
+      RETURN_IF_ERROR(auto_complete_io.AddString("name", io->name_));
+      RETURN_IF_ERROR(auto_complete_io.AddString(
+          "data_type", ConvertToModelConfigString(io->data_type_)));
+      triton::common::TritonJson::Value dims(
+          model_state_->ModelConfig(),
+          triton::common::TritonJson::ValueType::ARRAY);
+      RETURN_ERROR_IF_TRUE(
+          io->shape_->rank_ == 0, TRITONSERVER_ERROR_INVALID_ARG,
+          std::string(
+              "Unable to autofill for '" + model_state_->Name() +
+              "': the rank of model tensor '" + io->name_ +
+              "' is 0 which is not supported"));
+      // The model signature supports batching then the first
+      // dimension is -1 and should not appear in the model
+      // configuration 'dims' that we are creating.
+      for (size_t i = (model_support_batching_ ? 1 : 0); i < io->shape_->rank_;
+          ++i) {
+        RETURN_IF_ERROR(dims.AppendInt(io->shape_->dims_[i]));
+      }
+
+      // If io dims are empty then must use a reshape for the
+      // io, since 'dims' is not allowed to be empty.
+      if (dims.ArraySize() == 0) {
+        RETURN_IF_ERROR(dims.AppendInt(1));
+        triton::common::TritonJson::Value reshape(
+            model_state_->ModelConfig(),
+            triton::common::TritonJson::ValueType::OBJECT);
+        triton::common::TritonJson::Value reshape_dims(
+            model_state_->ModelConfig(),
+            triton::common::TritonJson::ValueType::ARRAY);
+        RETURN_IF_ERROR(reshape.Add("shape", std::move(reshape_dims)));
+        RETURN_IF_ERROR(auto_complete_io.Add("reshape", std::move(reshape)));
+      }
+      RETURN_IF_ERROR(auto_complete_io.Add("dims", std::move(dims)));
+      RETURN_IF_ERROR(auto_complete_ios.Append(std::move(auto_complete_io)));
+    }
+    if (found_ios) {
+      ios.Swap(auto_complete_ios);
+    } else {
+      model_state_->ModelConfig().Add("output", std::move(auto_complete_ios));
+    }
+  } else {
+    // don't need to copy here since we don't need to keep track of what 
+    // we need to check at the end.
+    triton::common::TritonJson::Value current_io(
+      model_state_->ModelConfig(),
+      triton::common::TritonJson::ValueType::OBJECT);
+    for (size_t i = 0; i < ios.ArraySize(); ++i) {
+      ios.IndexAsObject(i, &current_io);
+
+      std::string output_name;
+      RETURN_IF_ERROR(current_io.MemberAsString("name", &output_name));
+
+      TRITONTF_IO* io = FindModelIOByName(output_name.c_str(), reference_list);
+
+      // may want to rethink the swap in this
+      FillMissingValues(io, current_io);
+    }
+  }
+  return nullptr;  // success
+}
+
+
 TRITONSERVER_Error*
 AutoCompleteHelper::FillMissingValues(
     const TRITONTF_IO* io, triton::common::TritonJson::Value& io_config)
@@ -1437,9 +1798,18 @@ AutoCompleteHelper::CopyList(const TRITONTF_IOList* src, std::vector<const TRITO
 TRITONSERVER_Error*
 AutoCompleteHelper::FixConfigInputs(const TRITONTF_IOList* reference_list)
 {
+<<<<<<< HEAD
+=======
+
+  //nocheckin
+  triton::common::TritonJson::WriteBuffer json_buffer;
+
+  // Replace I/O even if inputs / outputs are specified in config.
+>>>>>>> messy debug code
   triton::common::TritonJson::Value ios;
   model_state_->ModelConfig().Find("input", &ios);
 
+<<<<<<< HEAD
   // Iterate through the model config inputs and keep track of
   // the ones which we found in the model. Any inputs left in the 
   // model list, we will attempt to autocomplete after. In the 
@@ -1449,6 +1819,13 @@ AutoCompleteHelper::FixConfigInputs(const TRITONTF_IOList* reference_list)
   CopyList(reference_list, reference_list_copy);
 
   triton::common::TritonJson::Value current_io(
+=======
+  json_buffer.Clear();
+  ios.PrettyWriteValue(&json_buffer);
+  LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("IOS: \n") + json_buffer.Contents()).c_str());
+
+  triton::common::TritonJson::Value auto_complete_ios(
+>>>>>>> messy debug code
       model_state_->ModelConfig(),
       triton::common::TritonJson::ValueType::OBJECT);
   for (size_t i = 0; i < ios.ArraySize(); ++i) {
@@ -1560,12 +1937,78 @@ AutoCompleteHelper::FixConfigOutputs(const TRITONTF_IOList* reference_list)
     for (size_t i = 0; i < ios.ArraySize(); ++i) {
       ios.IndexAsObject(i, &current_io);
 
+<<<<<<< HEAD
       std::string output_name;
       RETURN_IF_ERROR(current_io.MemberAsString("name", &output_name));
 
       const TRITONTF_IO* io = FindIOByName(reference_list, output_name);
       if (io == nullptr) {
         continue;
+=======
+      model_state_->ModelConfig().Add(key, std::move(auto_complete_ios));
+    } else if (io->shape_->rank_ > 0 && found_ios) {
+      // The number of elements in dims should match 'rank - 1'
+      // when the model supports batching; otherwise, number of
+      // elements in dims should match 'rank'. This does not
+      // try to overwrite the user provided configuration, throws
+      // error instead.
+      // However, ragged batching is an exception to this rule. A
+      // tensor allowing ragged batch should not match with
+      // 'rank - 1'.
+      size_t io_size = ios.ArraySize();
+      for (size_t i = 0; i < io_size; ++i) {
+        triton::common::TritonJson::Value current_io_object(
+            model_state_->ModelConfig(),
+            triton::common::TritonJson::ValueType::OBJECT);
+        ios.IndexAsObject(i, &current_io_object);
+
+        json_buffer.Clear();
+        current_io_object.PrettyWriteValue(&json_buffer);
+        LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("CURRENT_IO_OBJECT: \n") + json_buffer.Contents()).c_str());
+
+        triton::common::TritonJson::Value current_dims(
+            model_state_->ModelConfig(),
+            triton::common::TritonJson::ValueType::ARRAY);
+        current_io_object.Find("dims", &current_dims);
+
+        json_buffer.Clear();
+        current_dims.PrettyWriteValue(&json_buffer);
+        LOG_MESSAGE(TRITONSERVER_LOG_INFO, (std::string("CURRENT_DIMS: \n") + json_buffer.Contents()).c_str());
+
+        size_t dims_size = dims.ArraySize();
+        size_t non_negative_dim_values = 0;
+        int64_t tmp;
+        for (size_t j = 0; j < dims_size; ++j) {
+          current_dims.IndexAsInt(j, &tmp);
+          if (tmp != -1) {
+            ++non_negative_dim_values;
+          }
+        }
+        size_t adjusted_dims_size = (model_support_batching_ ? dims_size -1 : dims_size);
+        LOG_MESSAGE(TRITONSERVER_LOG_ERROR, (std::string("ADJUSTED_DIMS_SIZE: \n") + std::to_string(adjusted_dims_size)).c_str() );
+
+        if (model_support_batching_) {
+          RETURN_ERROR_IF_TRUE(
+              current_dims.ArraySize() != (io->shape_->rank_ - 1),
+              TRITONSERVER_ERROR_INVALID_ARG,
+              std::string(
+                  "Number of dimensions (" + std::to_string(dims.ArraySize()) +
+                  ") given for '" + model_state_->Name() +
+                  "' in configuration does not match the rank (" +
+                  std::to_string(io->shape_->rank_ - 1) +
+                  ")of the loaded model."));
+        } else {
+          RETURN_ERROR_IF_TRUE(
+              current_dims.ArraySize() != io->shape_->rank_,
+              TRITONSERVER_ERROR_INVALID_ARG,
+              std::string(
+                  "Number of dimensions (" + std::to_string(dims.ArraySize()) +
+                  ") given for '" + model_state_->Name() +
+                  "' in configuration does not match the rank (" +
+                  std::to_string(io->shape_->rank_) +
+                  ") of the loaded model."));
+        }
+>>>>>>> messy debug code
       }
 
       FillMissingValues(io, current_io);

--- a/src/tensorflow.cc
+++ b/src/tensorflow.cc
@@ -1278,19 +1278,16 @@ AutoCompleteHelper::FixBatchingSupport()
                 TRITONTF_IO* io = itr->io_;
                 if (config_name == io->name_) {
                   bool model_io_explicit = io->shape_->rank_ > 0;
-                  bool model_shape_matches_config_shape =
-                      io->shape_->rank_ == config_dims.ArraySize() + 1
+                  bool model_shape_matches_config_shape_plus_1 =
+                      io->shape_->rank_ == config_dims.ArraySize() + 1;
 
-                                               // Check for false hints
-                                               if (!model_io_explicit &&
-                                                   config_dims.ArraySize() == 0)
-                  {
+                  // Check for false hints
+                  if (!model_io_explicit && config_dims.ArraySize() == 0) {
                     // don't have enough information to batch
                     config_batch_hint = false;
-                  }
-                  else if (
-                      model_io_explicit && !model_shape_matches_config_shape)
-                  {
+                  } else if (
+                      model_io_explicit &&
+                      !model_shape_matches_config_shape_plus_1) {
                     // inconsistent user provided input
                     return TRITONSERVER_ErrorNew(
                         TRITONSERVER_ERROR_INTERNAL,

--- a/src/tensorflow_utils.cc
+++ b/src/tensorflow_utils.cc
@@ -30,13 +30,15 @@
 
 namespace triton { namespace backend { namespace tensorflow {
 
-bool ModelSupportsBatch(std::vector<const TRITONTF_IOList*> model_ios) {
+bool
+ModelSupportsBatch(std::vector<const TRITONTF_IOList*> model_ios)
+{
   for (const auto& ios : model_ios) {
     for (const TRITONTF_IOList* itr = ios; itr != nullptr; itr = itr->next_) {
       TRITONTF_IO* io = itr->io_;
       if ((io->shape_->rank_) != 0 && (io->shape_->dims_[0] != -1)) {
         return false;
-      } 
+      }
     }
   }
 
@@ -132,8 +134,7 @@ FindIOByName(const TRITONTF_IOList* ios, const std::string& name)
 }
 
 const TRITONTF_IO*
-FindIOByName(
-    const std::vector<const TRITONTF_IOList*> ios, std::string& name)
+FindIOByName(const std::vector<const TRITONTF_IOList*> ios, std::string& name)
 {
   for (const auto itr : ios) {
     if (itr->io_->name_ == name) {

--- a/src/tensorflow_utils.cc
+++ b/src/tensorflow_utils.cc
@@ -30,6 +30,19 @@
 
 namespace triton { namespace backend { namespace tensorflow {
 
+bool ModelSupportsBatch(std::vector<const TRITONTF_IOList*> model_ios) {
+  for (const auto& ios : model_ios) {
+    for (const TRITONTF_IOList* itr = ios; itr != nullptr; itr = itr->next_) {
+      TRITONTF_IO* io = itr->io_;
+      if ((io->shape_->rank_) != 0 && (io->shape_->dims_[0] != -1)) {
+        return false;
+      } 
+    }
+  }
+
+  return true;
+}
+
 TRITONSERVER_Error*
 CompareDims(
     const std::string& model_name, const std::string& tensor_name,

--- a/src/tensorflow_utils.cc
+++ b/src/tensorflow_utils.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2022, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/tensorflow_utils.h
+++ b/src/tensorflow_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2022, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/tensorflow_utils.h
+++ b/src/tensorflow_utils.h
@@ -31,7 +31,8 @@
 
 namespace triton { namespace backend { namespace tensorflow {
 
-/// \return True if the provided model I/Os allow batching support; False otherwise
+/// \return True if the provided model I/Os allow batching support; False
+/// otherwise.
 bool ModelSupportsBatch(std::vector<const TRITONTF_IOList*> model_ios);
 
 /// \return nullptr if a TensorFlow shape can support a model

--- a/src/tensorflow_utils.h
+++ b/src/tensorflow_utils.h
@@ -31,6 +31,9 @@
 
 namespace triton { namespace backend { namespace tensorflow {
 
+/// \return True if the provided model I/Os allow batching support; False otherwise
+bool ModelSupportsBatch(std::vector<const TRITONTF_IOList*> model_ios);
+
 /// \return nullptr if a TensorFlow shape can support a model
 /// configuration shape. Dimensions with variable size in the
 /// TensorFlow shape can support any size in the corresponding model


### PR DESCRIPTION
This PR updates FixBatchingSupport to be more lenient with savedmodels which don't have their shapes explicitly saved in the model file.  These ambiguous models now default to batching if the model config defines batchable dimensions for I/Os which have no shaved shape. The consequence is we defer failure to when the user infers rather than constraining them on startup.