### PR TITLE
Fix the result parsing error caused by the return value of the tensorflow model as a scalar or rank unknow

### DIFF
--- a/src/tensorflow.cc
+++ b/src/tensorflow.cc
@@ -2109,17 +2109,17 @@ ModelInstanceState::ProcessRequests(
           // Calculate the number of elements corresponding to batchn_shape,
           // compare with the actual number of elements, verify batchn_shape,
           // and solve the case where the tensor rank value is 0 or unknown rank
-          size_t element_size = 0,actual_element_size = 0;
+          size_t tensor_element_cnt = 0,actual_tensor_element_cnt = 0;
           size_t byte_size = TRITONTF_TensorDataByteSize(output_tensor);
           size_t type_size = TRITONSERVER_DataTypeByteSize(datatype);
-          actual_element_size = byte_size/type_size;
+          actual_tensor_element_cnt = byte_size/type_size;
           if(!batchn_shape.empty()){
-            element_size = 1;
+            tensor_element_cnt = 1;
             for(size_t itr = 0;itr < batchn_shape.size();itr ++ ){
-              element_size*=batchn_shape[itr];
+              tensor_element_cnt*=batchn_shape[itr];
             }
           }
-          if(element_size != actual_element_size){
+          if(tensor_element_cnt != actual_tensor_element_cnt){
             batchn_shape.clear();
             batchn_shape.reserve(1);
             batchn_shape.push_back(actual_element_size);


### PR DESCRIPTION
### Problems encountered
The backend when the model returns a scalar or rank unknow, batchn_shape will be empty, but the data is not empty, resulting in incorrect result parsing

### Reason

- The rank value of the scalar is 0: https://chromium.googlesource.com/external/github.com/tensorflow/tensorflow/+/r0.7/tensorflow/g3doc/resources/dims_types.md
- The rank value of unknown rank is unstable, and 0 may also occur
- Model input and output labels that encounter this problem

> signature_def['predict_images']:
  The given SavedModel SignatureDef contains the following input(s):
    inputs['images'] tensor_info:
        dtype: DT_STRING
        shape: (-1)
        name: jpg_contents:0
  The given SavedModel SignatureDef contains the following output(s):
    outputs['angles'] tensor_info:
        dtype: DT_INT32
        shape: (-1)
        name: angles:0
    outputs['f'] tensor_info:
        dtype: DT_FLOAT
        shape: unknown_rank
        name: f:0
    outputs['keypoints'] tensor_info:
        dtype: DT_FLOAT
        shape: (-1, 10)
        name: strided_slice_17:0
    outputs['nums'] tensor_info:
        dtype: DT_INT32
        shape: ()
        name: nums:0
    outputs['pos'] tensor_info:
        dtype: DT_FLOAT
        shape: (-1, 4)
        name: pos:0
    outputs['probs'] tensor_info:
        dtype: DT_FLOAT
        shape: (-1)
        name: probs:0
    outputs['valid_nums'] tensor_info:
        dtype: DT_INT32
        shape: ()
        name: valid_nums:0
    outputs['version'] tensor_info:
        dtype: DT_INT32
        shape: ()
        name: Const:0
  Method name is: tensorflow/serving/predict

### Solutions

- Calculate the number of elements corresponding to batchn_shape and the actual number of elements
- If the two values do not match, then modify the batchn_shape to a single dimension: [actual number of elements]