### PR TITLE
Skip the auto-complete if the model file is not detected

### DIFF
--- a/src/tensorflow.cc
+++ b/src/tensorflow.cc
@@ -1763,21 +1763,21 @@ ModelState::AutoCompleteConfig()
           backend_config_->allow_soft_placement_,
           backend_config_->memory_limit_mb_, nullptr /* tftrt_config */,
           false /* auto_mixed precision */);
-    }
 
-    if (err != nullptr) {
-      std::string msg((err->msg_ == nullptr) ? "<unknown>" : err->msg_);
-      TRITONTF_ErrorDelete(err);
-      return TRITONSERVER_ErrorNew(
-          TRITONSERVER_ERROR_INTERNAL,
-          (std::string("unable to auto-complete model configuration for '") +
-           Name() + "', failed to load model: " + msg)
-              .c_str());
-    }
+      if (err != nullptr) {
+        std::string msg((err->msg_ == nullptr) ? "<unknown>" : err->msg_);
+        TRITONTF_ErrorDelete(err);
+        return TRITONSERVER_ErrorNew(
+            TRITONSERVER_ERROR_INTERNAL,
+            (std::string("unable to auto-complete model configuration for '") +
+             Name() + "', failed to load model: " + msg)
+                .c_str());
+      }
 
-    auto ach = AutoCompleteHelper(this, tritontf_model);
-    RETURN_IF_ERROR(ach.Fix());
-    RETURN_IF_ERROR(SetModelConfig());
+      auto ach = AutoCompleteHelper(this, tritontf_model);
+      RETURN_IF_ERROR(ach.Fix());
+      RETURN_IF_ERROR(SetModelConfig());
+    }
   }
 
   return nullptr;  // success


### PR DESCRIPTION
### Before
```
I1028 01:36:58.322978 5023 tensorflow.cc:2576] backend configuration:
{"cmdline":{"auto-complete-config":"true","min-compute-capability":"6.000000","backend-directory":"/opt/tritonserver/backends","default-max-batch-size":"4"}}
I1028 01:36:58.323195 5023 tensorflow.cc:2642] TRITONBACKEND_ModelInitialize: bad_model_file_name (version 1)
I1028 01:36:58.323565 5023 model_config_utils.cc:1838] ModelConfig 64-bit fields:
I1028 01:36:58.323573 5023 model_config_utils.cc:1840] 	ModelConfig::dynamic_batching::default_queue_policy::default_timeout_microseconds
I1028 01:36:58.323581 5023 model_config_utils.cc:1840] 	ModelConfig::dynamic_batching::max_queue_delay_microseconds
I1028 01:36:58.323587 5023 model_config_utils.cc:1840] 	ModelConfig::dynamic_batching::priority_queue_policy::value::default_timeout_microseconds
I1028 01:36:58.323592 5023 model_config_utils.cc:1840] 	ModelConfig::ensemble_scheduling::step::model_version
I1028 01:36:58.323598 5023 model_config_utils.cc:1840] 	ModelConfig::input::dims
I1028 01:36:58.323606 5023 model_config_utils.cc:1840] 	ModelConfig::input::reshape::shape
I1028 01:36:58.323613 5023 model_config_utils.cc:1840] 	ModelConfig::instance_group::secondary_devices::device_id
I1028 01:36:58.323618 5023 model_config_utils.cc:1840] 	ModelConfig::model_warmup::inputs::value::dims
I1028 01:36:58.323623 5023 model_config_utils.cc:1840] 	ModelConfig::optimization::cuda::graph_spec::graph_lower_bound::input::value::dim
I1028 01:36:58.323629 5023 model_config_utils.cc:1840] 	ModelConfig::optimization::cuda::graph_spec::input::value::dim
I1028 01:36:58.323634 5023 model_config_utils.cc:1840] 	ModelConfig::output::dims
I1028 01:36:58.323639 5023 model_config_utils.cc:1840] 	ModelConfig::output::reshape::shape
I1028 01:36:58.323645 5023 model_config_utils.cc:1840] 	ModelConfig::sequence_batching::direct::max_queue_delay_microseconds
I1028 01:36:58.323650 5023 model_config_utils.cc:1840] 	ModelConfig::sequence_batching::max_sequence_idle_microseconds
I1028 01:36:58.323655 5023 model_config_utils.cc:1840] 	ModelConfig::sequence_batching::oldest::max_queue_delay_microseconds
I1028 01:36:58.323661 5023 model_config_utils.cc:1840] 	ModelConfig::sequence_batching::state::dims
I1028 01:36:58.323668 5023 model_config_utils.cc:1840] 	ModelConfig::sequence_batching::state::initial_state::dims
I1028 01:36:58.323675 5023 model_config_utils.cc:1840] 	ModelConfig::version_policy::specific::versions
Segmentation fault (core dumped)
```

### After

```
E1028 01:39:10.317576 5080 model_lifecycle.cc:597] failed to load 'bad_model_file_name' version 1: Unavailable: unable to find 'test_model/bad_modelfile_name/1/model.savedmodel' for model instance 'bad_modelfile_name'
```

