### PR TITLE
Run inference Ops in calling thread. Support TF_NUM_INTER_THREADS=-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ TRITON_TENSORFLOW_DOCKER_IMAGE set to refer to the new Docker image.
 Configuration of Tensorflow for a model is done through the Parameters section of the model's 'config.pbtxt' file. The parameters and their description are as follows.
 
 * `TF_NUM_INTRA_THREADS`: Number of threads to use to parallelize the execution of an individual op. Auto-configured by default. See [protobuf here](https://github.com/tensorflow/tensorflow/blob/6f72753a66d6abab8b839cc263a9f1329861f6f9/tensorflow/core/protobuf/config.proto#L393). Should be a non-negative number.
-* `TF_NUM_INTER_THREADS`: Controls the number of operators that can be executed simultaneously. Auto-configured by default. See [protobuf here](https://github.com/tensorflow/tensorflow/blob/6f72753a66d6abab8b839cc263a9f1329861f6f9/tensorflow/core/protobuf/config.proto#L404). Should be a non-negative number.
+* `TF_NUM_INTER_THREADS`: Controls the number of operators that can be executed simultaneously. Auto-configured by default. See [protobuf here](https://github.com/tensorflow/tensorflow/blob/6f72753a66d6abab8b839cc263a9f1329861f6f9/tensorflow/core/protobuf/config.proto#L404). Positive - set fixed pool size, -1 - use in calling thread inference.
 * `TF_USE_PER_SESSION_THREADS`: Boolean value to see if per session thread is used. "True", "On" and "1" are accepted as true.
 * `TF_GRAPH_TAG`: Tag of the graphs to use. See [protobuf here](https://github.com/tensorflow/tensorflow/blob/6f72753a66d6abab8b839cc263a9f1329861f6f9/tensorflow/core/protobuf/meta_graph.proto#L56)
 * `TF_SIGNATURE_DEF`: Signature def to use. See [protobuf here](https://github.com/tensorflow/tensorflow/blob/6f72753a66d6abab8b839cc263a9f1329861f6f9/tensorflow/core/protobuf/meta_graph.proto#L260-L331)

--- a/src/tensorflow.cc
+++ b/src/tensorflow.cc
@@ -1142,7 +1142,7 @@ ModelState::ParseParameters()
       } else {
         TRITONSERVER_ErrorDelete(err);
       }
-    } else if (num_inter_threads_ < 0) {
+    } else if (num_inter_threads_ < -1) {
       return TRITONSERVER_ErrorNew(
           TRITONSERVER_ERROR_INVALID_ARG,
           (std::string("parameter 'TF_NUM_INTER_THREADS' must be non-negative "


### PR DESCRIPTION
Tensorflow framework allow execute request with fine grain concurrency(INTRAOP pool) and per op concurrency (INTEROP pool).

While using CPU inference on multicore systems 16-32 default mode 32 INTRAOP x 32 INTEROP threads lead to overhead on dispatching ops and chunks of input data between threads of pool. For some lightweight models this overhead up to 50% of execution.

Base ability of triton server to run multiple instances of model with INTRAOP pool = 1, INTEROP pool = 1 bring higher efficiency.

For models which use embeddings approach with multiple model instances require N times more memory to store embedding hash tables as they are not reused between tensorflow sessions.

This patch to allow TF_NUM_INTER_THREADS=-1 which set Tensorflow to use inference in calling thread, therefore allows with configutaion
```pbtxt

name: "model"
platform: "tensorflow_savedmodel"
backend: "tensorflow"
max_batch_size: 10000
 input [
   ...
  ]
  output [
    ...
  ]

parameters: {
  key: "TF_NUM_INTRA_THREADS"
  value: {
    string_value:"1"
  }
}

parameters: {
  key: "TF_NUM_INTER_THREADS"
  value: {
    string_value:"-1"
  }
}

parameters: {
  key: "TF_USE_PER_SESSION_THREADS"
  value: {
    string_value:"1"
  }
}


parameters: {
  key: "MAX_SESSION_SHARE_COUNT"
  value: {
    string_value:"7"
  }
}

  instance_group [
    {
      count: 7
      kind: KIND_CPU
    }
  ]
```

Inference requests in parallel with low concurrency within execution graph.

PS: tensorflow backend should disable-auto-complete-config, is it tend not apply config.pbtxt params during autocompletion tf model and initializes thread pools with default values.
