### PR TITLE
Remove random selection fallback when signature def not found

### DIFF
--- a/mirror/tensorflow_backend_tf.cc
+++ b/mirror/tensorflow_backend_tf.cc
@@ -1,4 +1,4 @@
-// Copyright 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/mirror/tensorflow_backend_tf.cc
+++ b/mirror/tensorflow_backend_tf.cc
@@ -990,22 +990,10 @@ TRITONTF_ModelCreateFromSavedModel(
   auto sig_itr =
       bundle->meta_graph_def.signature_def().find(SIGNATURE_DEF_KEY_TO_USE);
   if (sig_itr == bundle->meta_graph_def.signature_def().end()) {
-    // If default serving signature_def key is not found, maybe it is named
-    // something else, use one that is neither init_op key nor train_op key
-    for (sig_itr = bundle->meta_graph_def.signature_def().begin();
-         sig_itr != bundle->meta_graph_def.signature_def().end(); sig_itr++) {
-      if ((sig_itr->first != INIT_OP_SIGNATURE_DEF_KEY) &&
-          (sig_itr->first != TRAIN_OP_SIGNATURE_DEF_KEY)) {
-        LOG(WARNING) << "unable to find serving signature '"
-                     << SIGNATURE_DEF_KEY_TO_USE;
-        LOG(WARNING) << "using signature '" << sig_itr->first << "'";
-        break;
-      }
-    }
-    if (sig_itr == bundle->meta_graph_def.signature_def().end()) {
-      return TRITONTF_ErrorNew(
-          "unable to load model '" + std::string(model_name) + "', expected '" +
-          SIGNATURE_DEF_KEY_TO_USE + "' signature");
+    // If serving signature_def key is not found, return error.
+    return TRITONTF_ErrorNew(
+        "unable to load model '" + std::string(model_name) + "', expected '" +
+        SIGNATURE_DEF_KEY_TO_USE + "' signature");
     }
   }
 

--- a/mirror/tensorflow_backend_tf.cc
+++ b/mirror/tensorflow_backend_tf.cc
@@ -994,7 +994,6 @@ TRITONTF_ModelCreateFromSavedModel(
     return TRITONTF_ErrorNew(
         "unable to load model '" + std::string(model_name) + "', expected '" +
         SIGNATURE_DEF_KEY_TO_USE + "' signature");
-    }
   }
 
   const tensorflow::SignatureDef& def = sig_itr->second;
@@ -1172,6 +1171,6 @@ TRITONTF_LoadAndRegisterLibrary(const char* path)
   if (status_code != TF_OK) {
     return TRITONTF_ErrorNew(status_msg);
   }
-  
+
   return nullptr;
 }

--- a/mirror/tensorflow_backend_tf.cc
+++ b/mirror/tensorflow_backend_tf.cc
@@ -990,7 +990,7 @@ TRITONTF_ModelCreateFromSavedModel(
   auto sig_itr =
       bundle->meta_graph_def.signature_def().find(SIGNATURE_DEF_KEY_TO_USE);
   if (sig_itr == bundle->meta_graph_def.signature_def().end()) {
-    // If serving signature_def key is not found, return error.
+    // If serving signature_def key is not found, return error
     return TRITONTF_ErrorNew(
         "unable to load model '" + std::string(model_name) + "', expected '" +
         SIGNATURE_DEF_KEY_TO_USE + "' signature");


### PR DESCRIPTION
Previously, if a signature def tag was not found, a random tag would be selected. This is not desirable behavior as it masks errors and users have no way to know a different tag was used without looking at the logs.

This PR removes that behavior in our TensorFlow mirror.

It does not make sense to add a test for the absence of a feature. To ensure these changes are successful, I tested locally and received the below results.

Before updates, model with wrong tag in config loads:
![image](https://user-images.githubusercontent.com/58150256/218828888-dcc93fd1-df76-481d-9ac9-dbd711b74f2e.png)

After updates, model with wrong tag in config fails to load:
![image](https://user-images.githubusercontent.com/58150256/218825556-a5e5adac-2a6c-4356-a61f-bf792a67b8ac.png)
