### PR TITLE
RHEL SBSA TF2 Backend Build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,16 +133,6 @@ endif() # TRITON_ENABLE_GPU
 configure_file(src/libtriton_tensorflow.ldscript libtriton_tensorflow.ldscript COPYONLY)
 
 if (${TRITON_TENSORFLOW_DOCKER_BUILD})
-  if (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "aarch64")
-    if(${RHEL_BUILD})
-      set(LIBS_ARCH "sbsa")
-    else()
-      set(LIBS_ARCH "aarch64")
-    endif()
-  else()
-    set(LIBS_ARCH "x86_64")
-  endif()
-
   add_custom_command(
     OUTPUT
       ${TRITON_TENSORFLOW_CC_LIBNAME}.${TRITON_TENSORFLOW_VERSION}
@@ -159,7 +149,7 @@ if (${TRITON_TENSORFLOW_DOCKER_BUILD})
     COMMAND docker stop tensorflow_backend_deps || echo "error ignored..." || true
     COMMAND docker rm tensorflow_backend_deps || echo "error ignored..." || true
     COMMAND if [ "${TRITON_TENSORFLOW_INSTALL_EXTRA_DEPS}" = "ON" ] \; then mkdir tf_backend_deps && docker run -it -d --name tensorflow_backend_deps ${TRITON_TENSORFLOW_DOCKER_IMAGE} \; fi \;
-    COMMAND if [ "${TRITON_TENSORFLOW_INSTALL_EXTRA_DEPS}" = "ON" ] \; then docker exec tensorflow_backend_deps sh -c  "tar -cf - $<IF:$<BOOL:${RHEL_BUILD}>,/usr/local/cuda/targets/${LIBS_ARCH}-linux/lib/,/usr/lib/${LIBS_ARCH}-linux-gnu/>libnccl.so*" | tar --strip-components=3 -xf - -C ./tf_backend_deps \; fi
+    COMMAND if [ "${TRITON_TENSORFLOW_INSTALL_EXTRA_DEPS}" = "ON" ] \; then docker exec tensorflow_backend_deps sh -c  "find $<IF:$<BOOL:${RHEL_BUILD}>,/usr/local/cuda/targets/*-linux/lib/,/usr/lib/*-linux-gnu/>libnccl.so*" | xargs -I {} docker cp tensorflow_backend_deps:{} ./tf_backend_deps \; fi
     COMMAND if [ "${TRITON_TENSORFLOW_INSTALL_EXTRA_DEPS}" = "ON" ] \; then docker stop tensorflow_backend_deps && docker rm tensorflow_backend_deps \; fi \;
 
     COMMENT "Extracting ${TRITON_TENSORFLOW_CC_LIBNAME}.${TRITON_TENSORFLOW_VERSION} and ${TRITON_TENSORFLOW_FW_LIBNAME}.${TRITON_TENSORFLOW_VERSION} from ${TRITON_TENSORFLOW_DOCKER_IMAGE}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,11 @@ configure_file(src/libtriton_tensorflow.ldscript libtriton_tensorflow.ldscript C
 
 if (${TRITON_TENSORFLOW_DOCKER_BUILD})
   if (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "aarch64")
-    set(LIBS_ARCH "aarch64")
+    if(${RHEL_BUILD})
+      set(LIBS_ARCH "sbsa")
+    else()
+      set(LIBS_ARCH "aarch64")
+    endif()
   else()
     set(LIBS_ARCH "x86_64")
   endif()
@@ -155,7 +159,7 @@ if (${TRITON_TENSORFLOW_DOCKER_BUILD})
     COMMAND docker stop tensorflow_backend_deps || echo "error ignored..." || true
     COMMAND docker rm tensorflow_backend_deps || echo "error ignored..." || true
     COMMAND if [ "${TRITON_TENSORFLOW_INSTALL_EXTRA_DEPS}" = "ON" ] \; then mkdir tf_backend_deps && docker run -it -d --name tensorflow_backend_deps ${TRITON_TENSORFLOW_DOCKER_IMAGE} \; fi \;
-    COMMAND if [ "${TRITON_TENSORFLOW_INSTALL_EXTRA_DEPS}" = "ON" ] \; then docker exec tensorflow_backend_deps sh -c  "tar -cf - $<IF:$<BOOL:${RHEL_BUILD}>,/usr/local/cuda/targets/x86_64-linux/lib/,/usr/lib/${LIBS_ARCH}-linux-gnu/>libnccl.so*" | tar --strip-components=3 -xf - -C ./tf_backend_deps \; fi
+    COMMAND if [ "${TRITON_TENSORFLOW_INSTALL_EXTRA_DEPS}" = "ON" ] \; then docker exec tensorflow_backend_deps sh -c  "tar -cf - $<IF:$<BOOL:${RHEL_BUILD}>,/usr/local/cuda/targets/${LIBS_ARCH}-linux/lib/,/usr/lib/${LIBS_ARCH}-linux-gnu/>libnccl.so*" | tar --strip-components=3 -xf - -C ./tf_backend_deps \; fi
     COMMAND if [ "${TRITON_TENSORFLOW_INSTALL_EXTRA_DEPS}" = "ON" ] \; then docker stop tensorflow_backend_deps && docker rm tensorflow_backend_deps \; fi \;
 
     COMMENT "Extracting ${TRITON_TENSORFLOW_CC_LIBNAME}.${TRITON_TENSORFLOW_VERSION} and ${TRITON_TENSORFLOW_FW_LIBNAME}.${TRITON_TENSORFLOW_VERSION} from ${TRITON_TENSORFLOW_DOCKER_IMAGE}"


### PR DESCRIPTION
**Goal**: Incorporate SBSA builds/tests and extended the smoke tests for x86 and SBSA to include L0_sequence_batcher.

Server changes: https://github.com/triton-inference-server/server/pull/7595
PyTorch Backend changes: https://github.com/triton-inference-server/pytorch_backend/pull/139
TensorRT Backend changes: https://github.com/triton-inference-server/tensorrt_backend/pull/99