### PR TITLE
Downgrade patchelf version from 0.18.0 to 0.17.2 

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,8 @@ explicitly provided, the default value for this option is 4.
 Use a recent cmake to build. First install the required dependencies.
 
 ```
-$ apt-get install patchelf rapidjson-dev
+$ apt-get install rapidjson-dev python3-pip
+$ pip3 install patchelf==0.17.2
 ```
 
 The backend can be built to support TensorFlow 2.x. Starting from 23.04, Triton


### PR DESCRIPTION
Downgrade patchelf version from 0.18.0 to 0.17.2 due to patchelf regression

Patchelf shipped a regression in 0.18.0 and has since yanked the pypi release pointing to
0.17.2 as the most recent version. However, 0.18.0 is still the version shipped in both the apt and yum
repositories, thus we must use pip to install the version we want.
See https://github.com/mayeut/patchelf-pypi/issues/87